### PR TITLE
add:ヘッダーの実装・dishes_controllerの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "sassc-rails"
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-# i18n
+# UI/UX
 gem 'rails-i18n'
 
 group :development, :test do

--- a/app/assets/images/brand_logo.svg
+++ b/app/assets/images/brand_logo.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="layer1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 28 14" enable-background="new 0 0 28 14" xml:space="preserve">
+<text transform="matrix(1 0 0 1 3.9248 4.3113)" font-family="'NicoMoji+v2'" font-size="6px">AI</text>
+<text transform="matrix(1 0 0 1 3.8374 9.0806)" font-family="'NicoMoji+v2'" font-size="6px">お料理</text>
+<text transform="matrix(1 0 0 1 3.8392 13.4022)" font-family="'NicoMoji+v2'" font-size="6px">ネーミング</text>
+<rect x="0.5" y="1.3" fill="#FFCE67" width="3" height="3"/>
+<rect x="0.5" y="5.8" fill="#FAB0A0" width="3" height="3"/>
+<rect x="0.5" y="10.3" fill="#F381FF" width="3" height="3"/>
+</svg>

--- a/app/assets/images/dropdown_icon.svg
+++ b/app/assets/images/dropdown_icon.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 26.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="layer1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 26" enable-background="new 0 0 24 26" xml:space="preserve">
+<g>
+	<g>
+		<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="0.4936" y1="13" x2="23.5064" y2="13">
+			<stop  offset="0" style="stop-color:#FFD277"/>
+			<stop  offset="1" style="stop-color:#F381FF"/>
+		</linearGradient>
+		
+			<line fill="none" stroke="url(#SVGID_1_)" stroke-width="3.9781" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="2.483" y1="13" x2="21.517" y2="13"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000065064194215626047050000002570695262470484360_" gradientUnits="userSpaceOnUse" x1="0.4936" y1="22.9085" x2="15.8925" y2="22.9085">
+			<stop  offset="0" style="stop-color:#FFD277"/>
+			<stop  offset="1" style="stop-color:#F381FF"/>
+		</linearGradient>
+		
+			<line fill="none" stroke="url(#SVGID_00000065064194215626047050000002570695262470484360_)" stroke-width="3.9781" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="2.483" y1="22.908" x2="13.903" y2="22.908"/>
+	</g>
+	<g>
+		
+			<linearGradient id="SVGID_00000175317248187705329280000001868353425351092619_" gradientUnits="userSpaceOnUse" x1="0.4936" y1="3.0915" x2="23.5064" y2="3.0915">
+			<stop  offset="0" style="stop-color:#FFD277"/>
+			<stop  offset="1" style="stop-color:#F381FF"/>
+		</linearGradient>
+		
+			<line fill="none" stroke="url(#SVGID_00000175317248187705329280000001868353425351092619_)" stroke-width="3.9781" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" x1="2.483" y1="3.092" x2="21.517" y2="3.092"/>
+	</g>
+</g>
+</svg>

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,4 @@
+@import 'custom/bootstrap_settings.scss';
+@import 'custom/style.scss';
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';

--- a/app/assets/stylesheets/custom/bootstrap_settings.scss
+++ b/app/assets/stylesheets/custom/bootstrap_settings.scss
@@ -1,0 +1,22 @@
+// bootstrapのテーマカラーの変更
+$primary:       #ffce67;
+$secondary:     #f381ff;
+$success:       #56cc9d;
+$info:          #0dcaf0;
+$warning:       #f3969a;
+$danger:        #ff7851;
+$light:         #f8f9fa;
+$dark:          #212529;
+
+// bootstrapのボタンの見た目を変更
+.btn {
+  border-radius: 50px !important;
+  padding: 8px 20px !important;
+  font-size: 14px !important;
+  font-weight: bold !important;
+}
+
+// ボタンの文字の色を変更
+.btn:hover {
+  color: #ffffff !important;
+}

--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -1,0 +1,63 @@
+// 992px以上の画面幅で適用される
+@media (min-width: 992px) {
+  .header {
+    margin: 0px 240px !important; // ブランドロゴとナビゲーションバーの間の余白を設定
+  }
+}
+
+// 992px以下の画面幅で適用される
+@media (max-width: 992px) {
+  .navbar-brand {
+    margin-left: 10px !important; // ブランドロゴの左の余白を設定
+  }
+}
+
+// ヘッダーに影をつける
+.navbar {
+  box-shadow: 0px 1px 3px 0px rgba(0,0,0,0.3);
+}
+
+// ドロップダウンメニューの背景設定
+.dropdown-background {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  background-color: #ffffff;
+  border-radius: 50%;
+  transition-property: background-color;
+  transition-duration: .2s;
+}
+
+.dropdown-background:hover {
+  background-color: rgb(244, 244, 244) !important;
+}
+
+// ドロップダウンメニューの設定
+.dropdown-icon {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  transition-property: opacity;
+  transition-duration: .2s;
+}
+
+.dropdown-icon:hover {
+  opacity: 0.8;
+}
+
+// ドロップダウンメニューのカードの設定
+.dropdown-menu {
+  border: 1px solid #fff !important;
+  border-radius: 10px !important;
+  box-shadow: 0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -2px rgba(0,0,0,.05) !important;
+}
+
+// ハンバーガーメニューのリストの設定
+.dropdown-item {
+  border-radius: 8px;
+}
+
+// fontawesomeのアイコンの色を変更
+.fontawesome {
+  font-size: 0.75em;
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+import "@fortawesome/fontawesome-free/js/all";

--- a/app/views/dishes/index.html.erb
+++ b/app/views/dishes/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Dishes#index</h1>
-<p>Find me in app/views/dishes/index.html.erb</p>

--- a/app/views/dishes/new.html.erb
+++ b/app/views/dishes/new.html.erb
@@ -1,2 +1,0 @@
-<h1>Dishes#new</h1>
-<p>Find me in app/views/dishes/new.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render "shared/before_login_header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,0 +1,20 @@
+<nav class="navbar navbar-expand navbar-light py-2">
+  <div class="container header">
+    <a class="navbar-brand" href="#">
+      <%= image_tag 'brand_logo.svg', size: '100x50'%>
+    </a>
+    <div class="btn-group">
+      <div class="dropdown-background" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
+        <%= image_tag 'dropdown_icon.svg', class:'dropdown-icon', size: '30x30'%>
+      </div>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li>
+          <a  class="dropdown-item" type="button"><i class="fa-solid fa-magnifying-glass me-3 fontawesome"></i>みんなの料理を見る</a>
+        </li>
+        <li><hr class="dropdown-divider"></li>
+        <li><a class="dropdown-item" type="button"><i class="fa-solid fa-right-to-bracket me-3 fontawesome"></i>ログイン</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,31 @@
+<nav class="navbar navbar-expand navbar-light py-2">
+  <div class="container header">
+    <a class="navbar-brand" href="#">
+      <%= image_tag 'brand_logo.svg', size: '100x50'%>
+    </a>
+    <div class="btn-group">
+      <div class="dropdown-background" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
+        <%= image_tag 'dropdown_icon.svg', class:'dropdown-icon', size: '30x30'%>
+      </div>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li>
+          <a  class="dropdown-item" type="button"><i class="fa-solid fa-magnifying-glass me-3 fontawesome"></i>みんなの料理を見る</a>
+        </li>
+        <li><hr class="dropdown-divider"></li>
+        <li class='text-center pb-2'>
+          <%= image_tag '100x100.png', class: 'rounded-circle', size:'60x60' %>
+        </li>
+        <li>
+          <a class="dropdown-item"><i class="fa-solid fa-utensils me-3 fontawesome"></i>自分の料理一覧</a>
+        </li>
+        <li>
+          <a class="dropdown-item" type="button"><i class="fa-solid fa-heart me-3 fontawesome"></i>いいねした料理</a>
+        </li>
+        <li><a class="dropdown-item" type="button"><i class="fa-solid fa-pen-to-square me-3 fontawesome"></i>プロフィール編集</a>
+        </li>
+        <li><a class="dropdown-item" type="button"><i class="fa-solid fa-right-from-bracket me-3 fontawesome"></i>ログアウト</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "private": "true",
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.4.0",
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.3.0",
     "@popperjs/core": "^2.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,6 +112,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz#8cfaf2ff603e9aabb910e9c0558c26cf32744061"
   integrity sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==
 
+"@fortawesome/fontawesome-free@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.0.tgz#1ee0c174e472c84b23cb46c995154dc383e3b4fe"
+  integrity sha512-0NyytTlPJwB/BF5LtRV8rrABDbe3TdTXqNB3PdZ+UUUZAEIrdOJdmABqKjt4AXwIoJNaRVVZEXxpNrqvE1GAYQ==
+
 "@hotwired/stimulus@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"


### PR DESCRIPTION
## 概要
issue #3 #42 
- ログイン/非ログイン時のヘッダーの実装を行なった。(bootstrap・fontawesome使用)
- bootstrapはテーマカラーの変更を行なった。
  - ログイン時
![スクリーンショット 2023-05-25 0 09 33](https://github.com/consolelogfuku/ai-oryouri-naming/assets/108031744/8be1f4ab-abad-4d2c-b699-1fc237c7b371)
  - 非ログイン時  
![スクリーンショット 2023-05-25 0 10 27](https://github.com/consolelogfuku/ai-oryouri-naming/assets/108031744/859f21f8-4722-4b6a-b73b-002035abed65)

- dishes_controllerの作成も行なった。(ヘッダーの実装とは別にプルリクすべきであった)