### PR TITLE
fix:herokuに接続できなかったため、dish_attribureモデルの文法ミスを修正

### DIFF
--- a/app/models/dish_attribute.rb
+++ b/app/models/dish_attribute.rb
@@ -1,4 +1,4 @@
 class DishAttribute < ApplicationRecord
-  validates: name, presence: true
-  validates: type, presence: true
+  validates :name, presence: true
+  validates :type, presence: true
 end


### PR DESCRIPTION
## 概要
issue:#78