### PR TITLE
add:flashメッセージの実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
 class ApplicationController < ActionController::Base
-
+  add_flash_types :success, :info, :warning, :danger
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,9 +7,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path
+      redirect_to root_path, success: t('.success')
     else
-      render:new
+      flash.now[:warning] = t('.fail')
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,8 @@
   </head>
 
   <body>
-    <%= render 'shared/header' %>
+    <%= render 'shared/before_login_header' %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,3 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>" role="alert"><%= message %></div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -27,7 +27,7 @@
             <%= f.password_field :password_confirmation, class: 'form-control flex-fill', placeholder: User.human_attribute_name(:password_confirmation) %>
           </div>
           <div class="text-center">
-            <%= f.submit class: 'btn btn-primary mt-5'%>
+            <%= f.submit class: 'btn btn-primary mt-4'%>
           </div>
         <% end %>
       </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,8 @@ module AIOryouriNaming
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # field_with_errorsタグを読み込まないようにする(Formのレイアウトが崩れるのを防ぐ)
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,6 +1,9 @@
 ja:
   defaults:
-  
+  users:
+    create:
+      success: 'ユーザー登録が完了しました'
+      fail: 'ユーザー登録に失敗しました'
   dishes:
     new:
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   root to: 'dishes#new'
   get 'sign_up', to: 'users#new'
+  post 'sign_up', to: 'users#create'
 
   resources :users, param: :uuid, only: [:create, :show] 
   resources :dishes, param: :uuid do


### PR DESCRIPTION
## 概要
issue:#105
- flashメッセージの実装を行なった。ユーザー登録form内で、バリデーションに引っかかった項目は、自動的に`<div class=’field_with_errors’></div>`で囲われ、レイアウトが崩れてしまうため、`config/application.rb`に`field_with_errors`タグを読み込まないようにするコードを記載した。