### PR TITLE
add:未ログインでも料理名生成機能が使えるように設定

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -1,5 +1,5 @@
 class DishesController < ApplicationController
-  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_login, only: %i[new create result]
 
   def index
   end
@@ -13,8 +13,8 @@ class DishesController < ApplicationController
   end
 
   def create
-    user = User.find(11)
-    # 料理を保存
+    user = User.set_guest_if_not_logedin(current_user)
+    # 料理名生成時に、ログインしていなければ、自動的にゲストユーザーの設定をする
     @dish = user.dishes.build(dish_params)
     if @dish.save_with_ingredients_and_cooking_methods(name_1: params.dig(:dish, :name_1), name_2: params.dig(:dish, :name_2), name_3: params.dig(:dish, :name_3), cooking_methods_name: params.dig(:dish, :cooking_methods_name))
       redirect_to result_dish_path(@dish.uuid)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user) # 新規ユーザー作成後、自動でログイン
       redirect_to root_path, success: t('.success')
     else
       flash.now[:warning] = t('.fail')

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -37,7 +37,7 @@ class Dish < ApplicationRecord
       save!
     end
   end
-
+  
   private
 
   # 料理名を生成
@@ -69,6 +69,7 @@ class Dish < ApplicationRecord
     self.dish_name = response.dig("choices", 0, "message", "content").gsub(/["「」]/, '')
     save!
   end
+
 
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,4 +15,13 @@ class User < ApplicationRecord
   def to_param
     uuid
   end
+  
+  def self.set_guest_if_not_logedin(current_user)
+    current_user.nil? ? User.new(
+      name: 'ゲスト',
+      email: SecureRandom.alphanumeric(10) + "@email.com",
+      password: 'password',
+      password_confirmation: 'password'
+    ) : current_user
+  end
 end


### PR DESCRIPTION
## 概要
issue:#121
- クラスメソッドset_guest_if_not_logedinをuser.rbに定義
-Topページにある料理名生成ボタンを押したときに、
　- ログインしていれば、current_userに紐づいたdishを生成
　- ログインしていなければ、guest設定を行う(current_userはnilのまま)