### PR TITLE
fix:フォームに何も入力しない状態で生成機能を使用した場合、エラーが発生する問題を修正

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -1,22 +1,24 @@
 class DishesController < ApplicationController
   skip_before_action :require_login, only: %i[new create result]
+  before_action :setup_dish, only: %i[new create] # createメソッドでは、else句が走った場合に必要
 
   def index
   end
 
   def new
     @dish = Dish.new
-    @cooking_methods = CookingMethod.all
-    @seasonings = Seasoning.all
-    @textures = Texture.all
-    @categories = Category.all
   end
 
   def create
-    user = User.set_guest_if_not_logedin(current_user)
-    # 料理名生成時に、ログインしていなければ、自動的にゲストユーザーの設定をする
+    # 料理名生成時に、ログインしていなければ、自動的にゲストユーザー設定をする
+    user = User.set_guest_if_not_logedin(current_user) # user.rb内でcurrent_userを使用できるようにするため、引数を渡す
     @dish = user.dishes.build(dish_params)
-    if @dish.save_with_ingredients_and_cooking_methods(name_1: params.dig(:dish, :name_1), name_2: params.dig(:dish, :name_2), name_3: params.dig(:dish, :name_3), cooking_methods_name: params.dig(:dish, :cooking_methods_name))
+    if @dish.save_with_ingredients_and_cooking_methods(
+      name_1: params.dig(:dish, :name_1),
+      name_2: params.dig(:dish, :name_2),
+      name_3: params.dig(:dish, :name_3),
+      cooking_methods_name: params.dig(:dish, :cooking_methods_name)
+    )
       redirect_to result_dish_path(@dish.uuid)
     else
       flash.now[:warning] = t('.fail')
@@ -45,5 +47,13 @@ class DishesController < ApplicationController
   def dish_params
     params.require(:dish).permit(:seasoning_id, :texture_id, :category_id, :point, :dish_image)
   end
+
+  def setup_dish # 選択肢を生成するのに必要
+    @cooking_methods = CookingMethod.all
+    @seasonings = Seasoning.all
+    @textures = Texture.all
+    @categories = Category.all
+  end
+
 
 end

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -31,9 +31,11 @@ class Dish < ApplicationRecord
       # 食材(同じ食材の組み合わせがあった場合は、その食材を取得する)
       self.ingredient = Ingredient.find_or_create_by(name_1: name_1, name_2: name_2, name_3: name_3)
       # 調理法
-      cooking_methods_name.each do |cooking_method_name|
+      cooking_methods_name&.each do |cooking_method_name|
         self.cooking_methods << CookingMethod.find_by(name: cooking_method_name)
       end
+      # save! は例外を表示させないだけで、例外は発生している(例外表示させない代わりにroot_pathに飛ばされる)
+      return false unless self.valid? # 保存できなかった時にfalseを返して、createメソッドのelse句を走らせる
       save!
     end
   end
@@ -61,7 +63,7 @@ class Dish < ApplicationRecord
     client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
     response = client.chat(
       parameters: {
-          model: "gpt-4",
+          model: "gpt-3.5-turbo",
           messages: [{ role: "user", content: content}],
           temperature: 1.0,
       })

--- a/app/views/dishes/new.html.erb
+++ b/app/views/dishes/new.html.erb
@@ -38,7 +38,6 @@
 <div class="main-content pb-4">
   <h5 class="main-content-title fw-bold text-center pt-5 pb-4">▼ 料理情報を入力しよう ▼</h5>
     <%= form_with model: @dish do |f| %>
-      <%= render 'shared/error_messages', object: f.object %>
       <%# 食材 %>
       <div class="ingredient">
         <div class="container">


### PR DESCRIPTION
## 概要
issue:#113
- dish.rb内の`save_with_ingredients_and_cooking_methods`メソッドを修正
  - `cooking_methods_name`がnilの場合、例外が発生してしまっていたため、ぼっち演算子を用いて例外を回避。
  - saveできなかった場合に、dishes_controllerのcreateメソッド内のelse句が走らなかったため、saveできない場合はfalseを返すようにエラーハンドリングを行なった。