### PR TITLE
add:料理名生成結果画面に、「もう一度名前をつける」「公開する」「ログインする」ボタンの設置

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -43,6 +43,14 @@ class DishesController < ApplicationController
     @dish = Dish.find_by(uuid: params[:uuid])
   end
 
+  # ステータスを公開に変更
+  def publish
+    @dish = Dish.find_by(uuid: params[:uuid])
+    @dish.update!(state: 'published')
+    flash.now[:success] = t('.success')
+    render :result, status: :unprocessable_entity
+  end
+
   private
 
   def dish_params

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -14,8 +14,7 @@ class Dish < ApplicationRecord
   has_many :dishes_cooking_methods, dependent: :destroy
   has_many :cooking_methods, through: :dishes_cooking_methods
   
-  before_validation -> { self.uuid = SecureRandom.uuid }
-  validates :uuid, presence: true
+  before_create -> { self.uuid = SecureRandom.uuid }
   validates :point, length: { maximum: 20 } # 20文字以内
   validates :state, presence: true
   enum state: { draft: 0, published: 1 }
@@ -62,7 +61,7 @@ class Dish < ApplicationRecord
     client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
     response = client.chat(
       parameters: {
-          model: "gpt-4",
+          model: "gpt-3.5-turbo",
           messages: [{ role: "user", content: content}],
           temperature: 1.0,
       })

--- a/app/views/dishes/result.html.erb
+++ b/app/views/dishes/result.html.erb
@@ -1,4 +1,4 @@
-<div class="ribbon py-4 mt-2 mb-1 fw-bold fs-4">あなたの料理名は...</div>
+<div class="ribbon py-4 mt-2 mb-1 fw-bold fs-4"><%= t('.title') %></div>
 <div class="result">
   <%# アニメーション %>
   <ul class="circles">
@@ -95,6 +95,24 @@
               </div>
             </div>
           </div>
+        <% end %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col text-center">
+        <%= link_to t('.re_generate'), root_path,class:'btn btn-outline-secondary' %>
+      </div>
+    </div>
+    <div class="row mt-4">
+      <div class="col text-center">
+        <%# ログイン/未ログインで表示を変化 %>
+        <% if logged_in? %>
+          <%= link_to t('.publish'), '#', class: 'btn btn-primary' %>
+          <p class='mt-4 fw-bold'>\ みんなの料理掲示板で公開しよう /</p>
+          <p class='mt-2 mb-5'>※あとからマイページの編集画面で非公開にできます。</p>
+        <% else %>
+          <%= link_to t('.login'), login_path, class: 'btn btn-primary' %>
+          <p class='mt-4 mb-5 fw-bold'>\ ログインすると、次回から結果を保存できるよ /</p>
         <% end %>
       </div>
     </div>

--- a/app/views/dishes/result.html.erb
+++ b/app/views/dishes/result.html.erb
@@ -107,7 +107,7 @@
       <div class="col text-center">
         <%# ログイン/未ログインで表示を変化 %>
         <% if logged_in? %>
-          <%= link_to t('.publish'), '#', class: 'btn btn-primary' %>
+          <%= link_to t('.publish'), publish_dish_path, class: 'btn btn-primary', data: { turbo_method: :patch } %>
           <p class='mt-4 fw-bold'>\ みんなの料理掲示板で公開しよう /</p>
           <p class='mt-2 mb-5'>※あとからマイページの編集画面で非公開にできます。</p>
         <% else %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -31,6 +31,12 @@ ja:
       generate: 'AIに名前をつけてもらう'
     create:
       fail: '名前をつけられませんでした'
+    result:
+      title: 'あなたの料理名は...'
+      re_generate: 'もう一度名前をつける'
+      login: 'ログインする'
+      publish: '公開する'
+
   profiles:
     edit:
       title: 'プロフィール編集'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -36,6 +36,8 @@ ja:
       re_generate: 'もう一度名前をつける'
       login: 'ログインする'
       publish: '公開する'
+    publish:
+      success: '公開しました'
 
   profiles:
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :users, param: :uuid, only: [:create, :show] 
   resources :dishes, param: :uuid do
     get 'result', on: :member
+    patch 'publish', on: :member
   end
   resources :password_resets, only: %i[new create edit update]
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? # letter_opener_web用

--- a/db/migrate/20230810140331_add_index_dishes_uuid.rb
+++ b/db/migrate/20230810140331_add_index_dishes_uuid.rb
@@ -1,0 +1,5 @@
+class AddIndexDishesUuid < ActiveRecord::Migration[7.0]
+  def change
+    add_index :dishes, :uuid, unique: true
+  end
+end

--- a/db/migrate/20230810141826_change_column_to_allow_null.rb
+++ b/db/migrate/20230810141826_change_column_to_allow_null.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToAllowNull < ActiveRecord::Migration[7.0]
+  def up
+    change_column :dishes, :uuid,:string, null: true
+  end
+
+  def down
+    change_column :dishes, :uuid,:string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_03_113450) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_10_141826) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_113450) do
     t.bigint "seasoning_id", null: false
     t.bigint "texture_id", null: false
     t.bigint "category_id", null: false
-    t.string "uuid", null: false
+    t.string "uuid"
     t.string "dish_name"
     t.string "point"
     t.string "dish_image"
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_03_113450) do
     t.index ["seasoning_id"], name: "index_dishes_on_seasoning_id"
     t.index ["texture_id"], name: "index_dishes_on_texture_id"
     t.index ["user_id"], name: "index_dishes_on_user_id"
+    t.index ["uuid"], name: "index_dishes_on_uuid", unique: true
   end
 
   create_table "dishes_cooking_methods", force: :cascade do |t|


### PR DESCRIPTION
## 概要
issue:#144
- 料理名生成結果画面において
  - ログインしている場合...「公開する」ボタンを表示(料理掲示板に公開できる)
  - 未ログインの場合...「ログインする」ボタンを表示