### PR TITLE
add:料理投稿詳細ページの実装

### DIFF
--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -243,7 +243,7 @@
   //   background-color: #45ff89;
   // }
 
-// SignUpページ、ログインページ、料理名生成結果ページ
+// SignUpページ、ログインページ、料理名生成結果ページ、投稿詳細ページ
 .card-form {
   background-color: #eee;
 
@@ -253,13 +253,17 @@
     z-index: 1;
   }
 
+  &-bg-white {
+    background-color: #fff;
+  }
+
   &-content {
     border-radius: 25px;
     background-color: #fff;
   }
 }
 
-// 生成結果ページ
+// 生成結果ページ、投稿詳細ページ
 .result {
   position: relative;
   background-color: $light-yellow;
@@ -283,8 +287,7 @@
 
   &-dish-content {
     background-color: #eee;
-    border-radius: 10px;
-    opacity: 0.7;
+    border-radius: 5px;
   }
 
   &-dish-image {
@@ -325,4 +328,10 @@
     border-bottom: solid 15px transparent;
     border-left: solid 20px $dark-pink;/*折り返し部分*/
   }
+}
+
+// 投稿一覧のcardのデザイン
+.card-time {
+  color: #aca6a6;
+  font-size: 0.84em;
 }

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -1,5 +1,5 @@
 class DishesController < ApplicationController
-  skip_before_action :require_login, only: %i[index new create result]
+  skip_before_action :require_login, only: %i[index new show create result]
   before_action :setup_dish, only: %i[new create] # createメソッドでは、else句が走った場合に必要
 
   def index
@@ -31,6 +31,7 @@ class DishesController < ApplicationController
   end
 
   def show
+    @dish = Dish.find_by(uuid: params[:uuid])
   end
 
   def update

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -6,6 +6,9 @@
       <div class="card-body pt-0">
         <h5 class="card-title fw-bold"><%= dish.dish_name %></h5>
         <p class="card-text"><%= dish.user.name %></p>
+        <p class="card-time "><%= l dish.created_at, format: :long %></p>
+        <%= link_to dish_path(dish.uuid), class:'stretched-link' do %>
+        <% end %>
       </div>
     </div>
 </div>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -1,2 +1,79 @@
-<h1>Dishes#show</h1>
-<p>Find me in app/views/dishes/show.html.erb</p>
+<h3 class="fw-bold text-center mt-5"><%= @dish.dish_name %></h3>
+<div class="card-form-bg-white">
+  <div class="text-center my-4 result-dish-image"><%= image_tag 'dish-1.jpg', size: '280x210' %></div>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-10 mx-auto card-form-content py-4 px-4 mt-4 mb-5 border">
+        <%# 食材 %>
+        <%= Ingredient.model_name.human %>
+        <div class="row mb-4">
+          <div class="col-md-4 mt-2">
+            <%# 要素がない場合、cssのborderを表示させたくないため、条件分岐させる%>
+            <% if @dish.ingredient.name_1.present? %>
+              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_1 %></div>
+            <% end %>
+          </div>
+          <div class="col-md-4 mt-2">
+            <% if @dish.ingredient.name_2.present? %>
+              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_2 %></div>
+            <% end %>
+          </div>
+          <div class="col-md-4 mt-2">
+            <% if @dish.ingredient.name_3.present? %>
+              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_3 %></div>
+            <% end %>
+          </div>
+        </div>
+        <%# 調理法 %>
+        <%= CookingMethod.model_name.human %>
+        <div class="row mb-4">
+            <% @dish.cooking_methods.each do |cooking_method| %>
+              <div class="col-md-4 mt-2">
+                <div class="result-dish-content  py-1 ps-2">
+                  <%= cooking_method.name %>
+                </div>
+              </div>
+            <% end %>
+        </div>
+        <%# 味付け %>
+        <%= Seasoning.model_name.human %>
+        <div class="row mb-4">
+          <div class="col-md-4 mt-2">
+            <div class="result-dish-content py-1 ps-2">
+              <%= @dish.seasoning.name %>
+            </div>
+          </div>
+        </div>
+        <%# 食感 %>
+        <%= Texture.model_name.human %>
+        <div class="row mb-4">
+          <div class="col-md-4 mt-2">
+            <div class="result-dish-content  py-1 ps-2">
+              <%= @dish.texture.name %>
+            </div>
+          </div>
+        </div>
+        <%# カテゴリ %>
+        <%= Category.model_name.human %>
+        <div class="row mb-4">
+          <div class="col-md-4 mt-2">
+            <div class="result-dish-content  py-1 ps-2">
+              <%= @dish.category.name %>
+            </div>
+          </div>
+        </div>
+        <%# ポイント(要素がない場合、表示させない) %>
+        <% if @dish.point.present? %>
+          <%= Dish.human_attribute_name(:point) %>
+          <div class="row mb-4">
+            <div class="col-md-6 mt-2">
+              <div class="result-dish-content  py-1 ps-2">
+                <%= @dish.point %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,22 +1,27 @@
-<header class="header py-3 d-flex justify-content-between">
-  <%= link_to root_path, class: 'header-brand' do %>
-    <%= image_tag 'brand_logo.svg', size: '100x50'%>
-  <% end %>
-  <div class="header-dropdown">
-    <div class="header-dropdown-background" data-bs-toggle="dropdown">
-      <%= image_tag 'dropdown_icon.svg', class:'header-dropdown-icon', size: '30x30'%>
+<div class="sticky-top bg-white shadow-sm">
+  <header class="header py-3 d-flex justify-content-between">
+    <%= link_to root_path, class: 'header-brand' do %>
+      <%= image_tag 'brand_logo.svg', size: '100x50'%>
+    <% end %>
+    <div class="header-dropdown">
+      <div class="header-dropdown-background" data-bs-toggle="dropdown">
+        <%= image_tag 'dropdown_icon.svg', class:'header-dropdown-icon', size: '30x30'%>
+      </div>
+      <ul class="header-dropdown-menu dropdown-menu dropdown-menu-end shadow">
+        <li>
+          <%= link_to dishes_path, class:'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-magnifying-glass me-3 fontawesome"></i>
+            <%= t('defaults.see_cooking_board') %>
+          <% end %>
+        </li>
+        <li><hr class="dropdown-divider"></li>
+        <li>
+          <%= link_to login_path, class: 'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-right-to-bracket me-3 fontawesome"></i>
+            <%= t('defaults.login') %>
+          <% end %>
+        </li>
+      </ul>
     </div>
-    <ul class="header-dropdown-menu dropdown-menu dropdown-menu-end shadow">
-      <li>
-        <a  class="header-dropdown-item dropdown-item"><i class="fa-solid fa-magnifying-glass me-3 fontawesome"></i>みんなの料理を見る</a>
-      </li>
-      <li><hr class="dropdown-divider"></li>
-      <li>
-        <%= link_to login_path, class: 'header-dropdown-item dropdown-item' do %>
-          <i class="fa-solid fa-right-to-bracket me-3 fontawesome"></i>
-          <%= t('defaults.login') %>
-        <% end %>
-      </li>
-    </ul>
-  </div>
-</header>
+  </header>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,37 +1,42 @@
-<header class="header py-3 d-flex justify-content-between">
-  <%= link_to root_path, class: 'header-brand' do %>
-    <%= image_tag 'brand_logo.svg', size: '100x50'%>
-  <% end %>
-  <div class="header-dropdown">
-    <div class="header-dropdown-background" data-bs-toggle="dropdown">
-      <%= image_tag 'dropdown_icon.svg', class:'header-dropdown-icon', size: '30x30'%>
+<div class="sticky-top bg-white shadow-sm">
+  <header class="header py-3 d-flex justify-content-between">
+    <%= link_to root_path, class: 'header-brand' do %>
+      <%= image_tag 'brand_logo.svg', size: '100x50'%>
+    <% end %>
+    <div class="header-dropdown">
+      <div class="header-dropdown-background" data-bs-toggle="dropdown">
+        <%= image_tag 'dropdown_icon.svg', class:'header-dropdown-icon', size: '30x30'%>
+      </div>
+      <ul class="header-dropdown-menu dropdown-menu dropdown-menu-end shadow">
+        <li>
+          <%= link_to dishes_path, class:'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-magnifying-glass me-3 header-fontawesome"></i>
+            <%= t('defaults.see_cooking_board') %>
+          <% end %>
+        </li>
+        <li><hr class="dropdown-divider"></li>
+        <li class='text-center pb-2'>
+          <%= image_tag '100x100.png', class: 'rounded-circle', size:'60x60' %>
+        </li>
+        <li>
+          <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-utensils me-3 header-fontawesome"></i>自分の料理一覧</a>
+        </li>
+        <li>
+          <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-heart me-3 header-fontawesome"></i>いいねした料理</a>
+        </li>
+        <li>
+          <%= link_to '#', class:'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-pen-to-square me-3 header-fontawesome"></i>
+            <%= t('profiles.edit.title') %>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to logout_path, data: { turbo_method: :delete }, class: 'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-right-from-bracket me-3 header-fontawesome"></i>
+            <%= t('defaults.logout') %>
+          <% end %>
+        </li>
+      </ul>
     </div>
-    <ul class="header-dropdown-menu dropdown-menu dropdown-menu-end shadow">
-      <li>
-        <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-magnifying-glass me-3 header-fontawesome"></i>みんなの料理を見る</a>
-      </li>
-      <li><hr class="dropdown-divider"></li>
-      <li class='text-center pb-2'>
-        <%= image_tag '100x100.png', class: 'rounded-circle', size:'60x60' %>
-      </li>
-      <li>
-        <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-utensils me-3 header-fontawesome"></i>自分の料理一覧</a>
-      </li>
-      <li>
-        <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-heart me-3 header-fontawesome"></i>いいねした料理</a>
-      </li>
-      <li>
-        <%= link_to '#', data: { turbo_method: :delete }, class:'header-dropdown-item dropdown-item' do %>
-          <i class="fa-solid fa-pen-to-square me-3 header-fontawesome"></i>
-          <%= t('profiles.edit.title') %>
-        <% end %>
-      </li>
-      <li>
-        <%= link_to logout_path, data: { turbo_method: :delete }, class: 'header-dropdown-item dropdown-item' do %>
-          <i class="fa-solid fa-right-from-bracket me-3 header-fontawesome"></i>
-          <%= t('defaults.logout') %>
-        <% end %>
-      </li>
-    </ul>
-  </div>
-</header>
+  </header>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,8 @@ module AIOryouriNaming
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
-    #
+    # タイムゾーンの設定
+    config.time_zone = 'Asia/Tokyo'
     # 現在のロケールを日本に設定
     config.i18n.default_locale = :ja
     # 翻訳ファイルの読み込みパスを追加

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,7 @@ ja:
     register: '登録'
     logout: 'ログアウト'
     update: '更新'
+    see_cooking_board: 'みんなの料理をみる'
     message:
       require_login: 'ログインしてください'
   users:
@@ -31,6 +32,7 @@ ja:
       generate: 'AIに名前をつけてもらう'
     create:
       fail: '名前をつけられませんでした'
+    show:
     result:
       title: 'あなたの料理名は...'
       re_generate: 'もう一度名前をつける'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, param: :uuid, only: [:create, :show] 
+  resources :users, param: :uuid, only: %i[create show] 
   resources :dishes, param: :uuid do
     get 'result', on: :member
     patch 'publish', on: :member


### PR DESCRIPTION
## 概要
issue:#22
- 料理投稿詳細ページ(/dishes/uuid)の実装を行なった。併せて下記の実装も行なった。
  - headerリンク(みんなの料理をみる)の活性化、headerの固定
  - 料理投稿一覧画面で、それぞれのカード全体が  リンクになるようにストレッチリンクを設定
  - タイムゾーンの設定、それぞれのカードに作成日時の表示