### PR TITLE
add:自分の料理一覧の実装

### DIFF
--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -330,7 +330,7 @@
   }
 }
 
-// 投稿一覧のcardのデザイン
+// 料理一覧のcardのデザイン
 .card-time {
   color: #aca6a6;
   font-size: 0.84em;
@@ -342,4 +342,11 @@
   text-decoration-color: rgba(255, 231, 16, 0.4); /* 線の色 */
   text-underline-offset: -0.2em; /* 線の位置。テキストに重なるようにやや上部にする */
   text-decoration-skip-ink: none; /* 下線と文字列が重なる部分でも下線が省略されない（線が途切れない） */
+}
+
+// 公開中マーク
+.publish-mark {
+  position: absolute;
+  top: -20px;
+  left: -8px;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,11 @@ class UsersController < ApplicationController
     end
   end
 
+  def show
+    @dishes = current_user.dishes.order(created_at: :DESC).page(params[:page])
+  end
+
+
   private
 
   def user_params

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -3,12 +3,18 @@
     <div class="card-img-block">
       <%= image_tag 'dish-1.jpg', class:'card-img-top' %>
     </div>
-      <div class="card-body pt-0">
-        <h5 class="card-title fw-bold"><%= dish.dish_name %></h5>
-        <p class="card-text"><%= dish.user.name %></p>
-        <p class="card-time "><%= l dish.created_at, format: :long %></p>
-        <%= link_to dish_path(dish.uuid), class:'stretched-link' do %>
-        <% end %>
-      </div>
+    <div class="card-body pt-0">
+      <%# 自分の料理一覧でのみ「公開中」マークをつける %>
+      <% if current_page?(user_path(dish.user.uuid)) && dish.published? %>
+        <span class="publish-mark text-white px-2 py-2 rounded-pill bg-success">
+          <%= t('defaults.published') %>
+        </span>
+      <% end %>
+      <h5 class="card-title fw-bold"><%= dish.dish_name %></h5>
+      <p class="card-text"><%= dish.user.name %></p>
+      <p class="card-time "><%= l dish.created_at, format: :long %></p>
+      <%= link_to dish_path(dish.uuid), class:'stretched-link' do %>
+      <% end %>
     </div>
+  </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,10 @@
           <%= image_tag '100x100.png', class: 'rounded-circle', size:'60x60' %>
         </li>
         <li>
-          <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-utensils me-3 header-fontawesome"></i>自分の料理一覧</a>
+          <%= link_to user_path(current_user.uuid), class:'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-utensils me-3 header-fontawesome"></i>
+            <%= t('users.show.title') %>
+          <% end%>
         </li>
         <li>
           <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-heart me-3 header-fontawesome"></i>いいねした料理</a>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,13 @@
+<h3 class='text-center fw-bold mt-5'><%= t('.title') %></h3>
+<div class="container">
+  <div class="row">
+    <% if @dishes.present? %>
+      <%= render @dishes %>
+    <% else %>
+      <p><%= t('.no_data') %></p>
+    <% end %>
+    <div class='mt-4'>
+      <%= paginate @dishes %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,7 @@ ja:
     register: '登録'
     logout: 'ログアウト'
     update: '更新'
+    published: '公開中'
     see_cooking_board: 'みんなの料理をみる'
     message:
       require_login: 'ログインしてください'
@@ -13,6 +14,9 @@ ja:
     create:
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
+    show:
+      title: '自分の料理一覧'
+
   user_sessions:
     new:
       title: 'ログイン'


### PR DESCRIPTION
## 概要
issue:#23
- 自分の料理一覧画面の実装
  - user/uuidに料理一覧を実装
  - headerの「自分の料理一覧」リンクの活性化
  - 公開中の料理のみ「公開中」マークを表示 