### PR TITLE
add:いいね機能の実装

### DIFF
--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -339,16 +339,10 @@
 }
   // 編集/削除マーク
 .crud-menus {
-  z-index: 3;
-  position: absolute;
-  top: -10px;
-  right: 30px;
+  position: relative;
+  right: -160px;
   width: 80px;
   height: 20px;
-  backdrop-filter: blur(20px);
-  background-color: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(20px);
-  border-radius: 10px;
 
   &:hover {
     opacity: 0.7;
@@ -357,7 +351,6 @@
 
   &-1 {
     position: absolute;
-    top: 5px;
     right: 15px;
     width: 80px;
     height: 20px;
@@ -365,7 +358,6 @@
 
   &-2 {
     position: absolute;
-    top: 5px;
     right: -15px;
     width: 80px;
     height: 20px;
@@ -373,7 +365,7 @@
 
   &-slash {
     position: absolute;
-    top: 3px;
+    top: -2px;
     right: -38px;
     width: 80px;
     height: 20px;
@@ -383,4 +375,18 @@
 // プロフィール
 .profile-icon {
   background-color: $light-gray;
+}
+
+// いいねマーク
+.like {
+  position: absolute;
+  top: 344px;
+  right: 30px;
+  width: 25px;
+  height: 25px;
+  color: #f52121c8;
+
+  &:hover {
+    opacity: 0.7;
+  }
 }

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -66,11 +66,16 @@ class DishesController < ApplicationController
     render :result, status: :unprocessable_entity
   end
 
+  # いいね一覧を取得
+  def likes
+    @likes = current_user.like_dishes.includes(:user).order(created_at: :DESC)
+  end
+
   private
 
   def dish_params
     params.require(:dish).permit(:seasoning_id, :texture_id, :category_id, :point, :dish_image, :dish_image_cache,
-                                 :state)
+                                :state)
   end
 
   # 選択肢を生成するのに必要

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,16 @@
+class LikesController < ApplicationController
+
+  def create
+    dish = Dish.find_by(uuid: params[:uuid])
+    current_user.like(dish)
+    redirect_to params[:redirect_path]
+  end
+  
+  def destroy
+    dish = current_user.like_dishes.find_by(uuid: params[:uuid])
+    current_user.unlike(dish)
+    redirect_to params[:redirect_path], status: :see_other
+  end
+end
+
+

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -17,6 +17,7 @@ class Dish < ApplicationRecord
   belongs_to :category
   has_many :dishes_cooking_methods, dependent: :destroy
   has_many :cooking_methods, through: :dishes_cooking_methods
+  has_many :likes, dependent: :destroy
   enum state: { draft: 0, published: 1 }
 
   before_create -> { self.uuid = SecureRandom.uuid }

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,6 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :dish
+
+  validates :user_id, uniqueness: {scope: :dish_id}
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :dishes, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :like_dishes, through: :likes, source: :dish
 
   before_create -> { self.uuid = SecureRandom.uuid }
   validates :name, presence: true, length: { maximum: 15 } # 20文字以内
@@ -34,5 +36,17 @@ class User < ApplicationRecord
 
   def own?(object)
     id == object.user_id
+  end
+
+  def like(dish)
+    like_dishes << dish
+  end
+
+  def unlike(dish)
+    like_dishes.destroy(dish)
+  end
+
+  def like?(dish)
+    like_dishes.include?(dish)
   end
 end

--- a/app/views/dishes/_crud_menus.html.erb
+++ b/app/views/dishes/_crud_menus.html.erb
@@ -1,6 +1,6 @@
-<div class="crud-menus py-3 px-3" data-bs-toggle="dropdown">
+<div class="crud-menus" data-bs-toggle="dropdown">
   <i class="fa-solid fa-pen-to-square crud-menus-1"></i>
-  <p class='crud-menus-slash fw-bold'>/</p>
+  <p class='crud-menus-slash fw-bold mb-0'>/</p>
   <i class="fa-solid fa-trash crud-menus-2"></i>
 </div>
 <ul class="header-dropdown-menu dropdown-menu dropdown-menu-end shadow">
@@ -11,7 +11,7 @@
     <% end %>
   </li>
   <li>
-    <%= link_to dish_path(dish.uuid, redirect_path: request.url), data: { turbo_method: :delete }, class: 'header-dropdown-item dropdown-item' do %>
+    <%= link_to dish_path(dish.uuid, redirect_path: request.url), data: { turbo_method: :delete, turbo_confirm: t('defaults.message.delete_confirm') }, class: 'header-dropdown-item dropdown-item' do %>
       <i class="fa-solid fa-trash me-3 header-fontawesome"></i>
       <%= t('defaults.delete') %>
     <% end %>

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -8,19 +8,20 @@
       <% if current_page?(user_path(dish.user.uuid)) && dish.published? %>
         <%= render partial: 'dishes/published' %>
       <% end %>
-      <%# 自分の料理にはcrudボタン、そうでなければいいねボタン %>
-      <% if current_user&.own?(dish) %>
-        <%= render partial: 'dishes/crud_menus', locals: { dish: dish } %>
-      <% else %>
-        <%= render partial: 'dishes/likes_button', locals: { dish: dish } %>
-      <% end %>
       <%# 料理名 %>
       <h5 class="fw-bold"><%= link_to dish.dish_name, dish_path(dish.uuid), class:'card-title'  %></h5>
-      <%# ユーザーアバターとニックネーム %>
+      <%# アバター、ニックネーム、crud/いいね %>
       <div class="d-flex align-items-center mt-3">
         <%= image_tag dish.user.avatar.url , class: 'rounded-circle border border-3', size:'70x70' %>
-        <p class="card-text ms-2"><%= dish.user.name %></p>
+        <p class="card-text ms-2 mb-0"><%= dish.user.name %></p>
+        <%# 自分の料理にはcrudボタン、そうでなければいいねボタン %>
+        <% if current_user&.own?(dish) %>
+          <%= render partial: 'dishes/crud_menus', locals: { dish: dish } %>
+        <% else %>
+          <%= render partial: 'dishes/likes_button', locals: { dish: dish } %>
+        <% end %>
       </div>
+      <%# 日付 %>
       <p class="card-time text-end mb-0"><%= l dish.created_at, format: :long, class:'text-right' %></p>
     </div>
   </div>

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -8,9 +8,11 @@
       <% if current_page?(user_path(dish.user.uuid)) && dish.published? %>
         <%= render partial: 'dishes/published' %>
       <% end %>
-      <%# 自分の料理には編集/削除ボタンをつける %>
+      <%# 自分の料理にはcrudボタン、そうでなければいいねボタン %>
       <% if current_user&.own?(dish) %>
         <%= render partial: 'dishes/crud_menus', locals: { dish: dish } %>
+      <% else %>
+        <%= render partial: 'dishes/likes_button', locals: { dish: dish } %>
       <% end %>
       <%# 料理名 %>
       <h5 class="fw-bold"><%= link_to dish.dish_name, dish_path(dish.uuid), class:'card-title'  %></h5>

--- a/app/views/dishes/_like.html.erb
+++ b/app/views/dishes/_like.html.erb
@@ -1,3 +1,3 @@
 <%= link_to likes_path(uuid: dish.uuid, redirect_path: request.url), data: { turbo_method: :post } do %>
-  <i class="fa-regular fa-heart"></i>
+  <i class="fa-regular fa-heart like"></i>
 <% end %>

--- a/app/views/dishes/_like.html.erb
+++ b/app/views/dishes/_like.html.erb
@@ -1,0 +1,3 @@
+<%= link_to likes_path(uuid: dish.uuid, redirect_path: request.url), data: { turbo_method: :post } do %>
+  <i class="fa-regular fa-heart"></i>
+<% end %>

--- a/app/views/dishes/_likes_button.html.erb
+++ b/app/views/dishes/_likes_button.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.like?(dish) %>
+  <%# いいねしている場合 %>
+  <%= render 'unlike', dish: dish %>
+<% else %>
+  <%# いいねしていない場合 %>
+  <%= render 'like', dish: dish %>
+<% end %>

--- a/app/views/dishes/_likes_button.html.erb
+++ b/app/views/dishes/_likes_button.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.like?(dish) %>
+<% if current_user&.like?(dish) %>
   <%# いいねしている場合 %>
   <%= render 'unlike', dish: dish %>
 <% else %>

--- a/app/views/dishes/_unlike.html.erb
+++ b/app/views/dishes/_unlike.html.erb
@@ -1,0 +1,3 @@
+<%= link_to like_path(uuid: dish.uuid, redirect_path: request.url ), data: { turbo_method: :delete } do %>
+  <i class="fa-solid fa-heart"></i>
+<% end %>

--- a/app/views/dishes/_unlike.html.erb
+++ b/app/views/dishes/_unlike.html.erb
@@ -1,3 +1,3 @@
 <%= link_to like_path(uuid: dish.uuid, redirect_path: request.url ), data: { turbo_method: :delete } do %>
-  <i class="fa-solid fa-heart"></i>
+  <i class="fa-solid fa-heart like"></i>
 <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,7 @@ ja:
     see_cooking_board: 'みんなの料理をみる'
     message:
       require_login: 'ログインしてください'
+      delete_confirm: '削除してよいですか？'
 
   users:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,6 @@ Rails.application.routes.draw do
   end
   resource :profile, only: %i[edit update]
   resources :password_resets, only: %i[new create edit update]
+  resources :likes, param: :uuid, only: %i[create destroy]
   mount LetterOpenerWeb::Engine, at: '/letter_opener' if Rails.env.development? # letter_opener_web用
 end

--- a/db/migrate/20230814011927_create_likes.rb
+++ b/db/migrate/20230814011927_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :dish, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :likes, [:user_id, :dish_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,84 +10,95 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_230_813_113_804) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'cooking_methods', force: :cascade do |t|
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['name'], name: 'index_cooking_methods_on_name', unique: true
+  create_table "cooking_methods", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_cooking_methods_on_name", unique: true
   end
 
-  create_table 'dish_attributes', force: :cascade do |t|
-    t.string 'type', null: false
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "dish_attributes", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'dishes', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.bigint 'ingredient_id', null: false
-    t.bigint 'seasoning_id', null: false
-    t.bigint 'texture_id', null: false
-    t.bigint 'category_id', null: false
-    t.string 'uuid'
-    t.string 'dish_name'
-    t.string 'point'
-    t.string 'dish_image'
-    t.integer 'state', default: 0, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['category_id'], name: 'index_dishes_on_category_id'
-    t.index ['ingredient_id'], name: 'index_dishes_on_ingredient_id'
-    t.index ['seasoning_id'], name: 'index_dishes_on_seasoning_id'
-    t.index ['texture_id'], name: 'index_dishes_on_texture_id'
-    t.index ['user_id'], name: 'index_dishes_on_user_id'
-    t.index ['uuid'], name: 'index_dishes_on_uuid', unique: true
+  create_table "dishes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "ingredient_id", null: false
+    t.bigint "seasoning_id", null: false
+    t.bigint "texture_id", null: false
+    t.bigint "category_id", null: false
+    t.string "uuid"
+    t.string "dish_name"
+    t.string "point"
+    t.string "dish_image"
+    t.integer "state", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_dishes_on_category_id"
+    t.index ["ingredient_id"], name: "index_dishes_on_ingredient_id"
+    t.index ["seasoning_id"], name: "index_dishes_on_seasoning_id"
+    t.index ["texture_id"], name: "index_dishes_on_texture_id"
+    t.index ["user_id"], name: "index_dishes_on_user_id"
+    t.index ["uuid"], name: "index_dishes_on_uuid", unique: true
   end
 
-  create_table 'dishes_cooking_methods', force: :cascade do |t|
-    t.bigint 'dish_id', null: false
-    t.bigint 'cooking_method_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['cooking_method_id'], name: 'index_dishes_cooking_methods_on_cooking_method_id'
-    t.index %w[dish_id cooking_method_id], name: 'index_dishes_cooking_methods_on_dish_id_and_cooking_method_id',
-                                           unique: true
-    t.index ['dish_id'], name: 'index_dishes_cooking_methods_on_dish_id'
+  create_table "dishes_cooking_methods", force: :cascade do |t|
+    t.bigint "dish_id", null: false
+    t.bigint "cooking_method_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cooking_method_id"], name: "index_dishes_cooking_methods_on_cooking_method_id"
+    t.index ["dish_id", "cooking_method_id"], name: "index_dishes_cooking_methods_on_dish_id_and_cooking_method_id", unique: true
+    t.index ["dish_id"], name: "index_dishes_cooking_methods_on_dish_id"
   end
 
-  create_table 'ingredients', force: :cascade do |t|
-    t.string 'name_1'
-    t.string 'name_2'
-    t.string 'name_3'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "ingredients", force: :cascade do |t|
+    t.string "name_1"
+    t.string "name_2"
+    t.string "name_3"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'uuid'
-    t.string 'name', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'email', null: false
-    t.string 'crypted_password'
-    t.string 'salt'
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_token_expires_at'
-    t.datetime 'reset_password_email_sent_at'
-    t.integer 'access_count_to_reset_password_page', default: 0
-    t.string 'avatar'
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token'
-    t.index ['uuid'], name: 'index_users_on_uuid', unique: true
+  create_table "likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "dish_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dish_id"], name: "index_likes_on_dish_id"
+    t.index ["user_id", "dish_id"], name: "index_likes_on_user_id_and_dish_id", unique: true
+    t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
-  add_foreign_key 'dishes', 'ingredients'
-  add_foreign_key 'dishes', 'users'
-  add_foreign_key 'dishes_cooking_methods', 'cooking_methods'
-  add_foreign_key 'dishes_cooking_methods', 'dishes'
+  create_table "users", force: :cascade do |t|
+    t.string "uuid"
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.string "salt"
+    t.string "reset_password_token"
+    t.datetime "reset_password_token_expires_at"
+    t.datetime "reset_password_email_sent_at"
+    t.integer "access_count_to_reset_password_page", default: 0
+    t.string "avatar"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
+    t.index ["uuid"], name: "index_users_on_uuid", unique: true
+  end
+
+  add_foreign_key "dishes", "ingredients"
+  add_foreign_key "dishes", "users"
+  add_foreign_key "dishes_cooking_methods", "cooking_methods"
+  add_foreign_key "dishes_cooking_methods", "dishes"
+  add_foreign_key "likes", "dishes"
+  add_foreign_key "likes", "users"
 end


### PR DESCRIPTION
## 概要
issue:#28
- Likesテーブル、Likes_controller、Likeモデルの追加を行なった。
- Likes_controllerのcreateおよびdestroyメソッドについて、いいね/いいね解除を行なった後、redirect_backを実行するとなぜか直前のページにリダイレクトできなかったため、直前のページを`params[:redirect_path]`で取得し、redirect_toで指定してあげることで、直前のページにリダイレクトできるように実装した。