### PR TITLE
add:activemodelの翻訳データの追加、いいね一覧・各ユーザーの料理一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/custom/dish_card.scss
+++ b/app/assets/stylesheets/custom/dish_card.scss
@@ -19,14 +19,27 @@
     border-radius:3px;
     box-shadow:0 0 10px rgba(0,0,0,0.4);
   }
-}
 
-.card-title {
-  color: #424242 !important;
-  text-decoration: none;
-  border-bottom: 1px solid;
-}
+  .card-title {
+    color: #424242 !important;
+    text-decoration: none;
+    border-bottom: 1px solid;
+  }
+  
+  .card-title:hover {
+    opacity: 0.7;
+  }
 
-.card-title:hover {
-  opacity: 0.7;
+  .card-link {
+    text-decoration: none;
+  }
+  
+  .card-link:hover {
+    opacity: 0.7;
+  }
+
+  .card-text {
+    color: #424242 !important;
+  }
+
 }

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -61,7 +61,7 @@ class DishesController < ApplicationController
 
   # いいね一覧を取得
   def likes
-    @likes = current_user.like_dishes.includes(:user).order(created_at: :DESC)
+    @likes = current_user.like_dishes.includes(:user).order(created_at: :DESC).page(params[:page])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@ class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
 
   def show
-    @dishes = current_user.dishes.order(created_at: :DESC).page(params[:page])
+    @user = User.find_by(uuid: params[:uuid])
+    @dishes = @user.dishes.order(created_at: :DESC).page(params[:page])
   end
 
   def new

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -4,17 +4,19 @@
       <%= image_tag dish.dish_image_url, class:'card-img-top' %>
     </div>
     <div class="card-body pt-0">
-      <%# 自分の料理一覧ページでのみ「公開中」マークをつける %>
+      <%# 今、自分の料理一覧ページにいる且つ「公開中」 =>trueで 「公開中」マークつける %>
       <% if current_page?(user_path(dish.user.uuid)) && dish.published? %>
         <%= render partial: 'dishes/published' %>
       <% end %>
       <%# 料理名 %>
       <h5 class="fw-bold"><%= link_to dish.dish_name, dish_path(dish.uuid), class:'card-title'  %></h5>
-      <%# アバター、ニックネーム、crud/いいね %>
+      <%# アバター、ニックネーム %>
       <div class="d-flex align-items-center mt-3">
-        <div class="d-flex align-items-center flex-grow-1">
-          <%= image_tag dish.user.avatar.url , class: 'rounded-circle border border-3', size:'70x70' %>
-          <p class="card-text ms-2 mb-0"><%= dish.user.name %></p>
+        <div class="flex-grow-1 d-flex align-items-center">
+          <%= link_to user_path(dish.user.uuid), class:'d-flex align-items-center card-link ' do %>
+            <%= image_tag dish.user.avatar.url , class: 'rounded-circle border border-3 card-avatar', size:'70x70' %>
+            <p class="card-text ms-3 mb-0"><%= dish.user.name %></p>
+          <% end %>
         </div>
         <%# 自分の料理にはcrudボタン、そうでなければいいねボタン %>
         <% if current_user&.own?(dish) %>

--- a/app/views/dishes/_likes_button.html.erb
+++ b/app/views/dishes/_likes_button.html.erb
@@ -1,7 +1,7 @@
 <% if current_user&.like?(dish) %>
   <%# いいねしている場合 %>
-  <%= render 'unlike', dish: dish %>
+  <%= render 'dishes/unlike', dish: dish %>
 <% else %>
   <%# いいねしていない場合 %>
-  <%= render 'like', dish: dish %>
+  <%= render 'dishes/like', dish: dish %>
 <% end %>

--- a/app/views/dishes/likes.html.erb
+++ b/app/views/dishes/likes.html.erb
@@ -1,0 +1,13 @@
+<h3 class='text-center fw-bold mt-5'><%= t('.title') %></h3>
+<div class="container">
+  <div class="row">
+    <% if @likes.present? %>
+      <%= render @likes %>
+    <% else %>
+      <p><%= t('.no_data') %></p>
+    <% end %>
+    <div class='mt-4'>
+      <%= paginate @likes %>
+    </div>
+  </div>
+</div>

--- a/app/views/dishes/result.html.erb
+++ b/app/views/dishes/result.html.erb
@@ -108,7 +108,8 @@
         <%# ログイン/未ログインで表示を変化 %>
         <% if logged_in? %>
           <%= link_to t('.publish'), publish_dish_path, class: 'btn btn-primary', data: { turbo_method: :patch } %>
-          <p class='mt-4 mb-5'>※あとからマイページの編集画面で非公開にできます。</p>
+          <p class='mt-4'>掲示板に投稿して、みんなに見てもらおう！！</p>
+          <p class='mb-5 form-text'>※あとからマイページの編集画面で非公開にできます。</p>
         <% else %>
           <%= link_to t('.login'), login_path, class: 'btn btn-primary' %>
           <p class='mt-4 mb-5 fw-bold'>ログインすると次から結果を保存できるよ</p>
@@ -117,3 +118,14 @@
     </div>
   </div>
 </div>
+<a
+  tabindex="0"
+  class="btn btn-lg btn-danger"
+  role="button"
+  data-mdb-toggle="popover"
+  data-mdb-trigger="focus"
+  title="Dismissible popover"
+  data-mdb-content="And here's some amazing content. It's very engaging. Right?"
+>
+  Dismissible popover
+</a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,11 +21,14 @@
         <li>
           <%= link_to user_path(current_user.uuid), class:'header-dropdown-item dropdown-item' do %>
             <i class="fa-solid fa-utensils me-3 header-fontawesome"></i>
-            <%= t('users.show.title') %>
+            <%= t('users.show.my_dishes') %>
           <% end%>
         </li>
         <li>
-          <a class="header-dropdown-item dropdown-item"><i class="fa-solid fa-heart me-3 header-fontawesome"></i>いいねした料理</a>
+          <%= link_to likes_dishes_path, class:'header-dropdown-item dropdown-item' do %>
+            <i class="fa-solid fa-heart me-3 header-fontawesome"></i>
+            <%= t('defaults.likes_dishes') %>
+          <% end %>
         </li>
         <li>
           <%= link_to edit_profile_path, class:'header-dropdown-item dropdown-item' do %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,8 @@
-<h3 class='text-center fw-bold mt-5'><%= t('.title') %></h3>
+<% if @user == current_user %>
+  <h3 class='text-center fw-bold mt-5'><%= t('.my_dishes') %></h3>
+<% else %>
+  <h3 class='text-center fw-bold mt-5'><%= t('.someone_dishes', item: @user.name) %></h3>
+<% end %>
 <div class="container">
   <div class="row">
     <% if @dishes.present? %>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -1,0 +1,8 @@
+ja: 
+  activemodel:
+    models:
+      generate_form:
+    attributes:
+      generate_form:
+        point: 'ポイント'
+        dish_image: '料理写真'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -39,3 +39,4 @@ ja:
       category:
         id: 'ID'
         name: 'カテゴリー'
+  

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     delete: '削除する'
     published: '公開中'
     see_cooking_board: 'みんなの料理掲示板'
+    likes_dishes: 'いいねした料理'
     message:
       require_login: 'ログインしてください'
       delete_confirm: '削除してよいですか？'
@@ -19,7 +20,8 @@ ja:
       success: 'ユーザー登録が完了しました'
       fail: 'ユーザー登録に失敗しました'
     show:
-      title: '自分の料理一覧'
+      my_dishes: '自分の料理一覧'
+      someone_dishes: '%{item}の料理一覧'
       no_data: '料理がありません'
 
   user_sessions:
@@ -52,9 +54,11 @@ ja:
       title: 'あなたの料理名は...'
       re_generate: 'もう一度名前をつける'
       login: 'ログインする'
-      publish: '料理掲示板で公開する'
+      publish: '料理掲示板に投稿する'
     publish:
-      success: '公開しました'
+      success: '投稿しました'
+    likes:
+      title: 'いいねした料理'
 
   profiles:
     edit:
@@ -73,3 +77,4 @@ ja:
     update:
       success: 'パスワードを変更しました'
       fail: 'パスワードの変更に失敗しました'
+  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :dishes, param: :uuid do
     get 'result', on: :member
     patch 'publish', on: :member
+    get 'likes', on: :collection
   end
   resource :profile, only: %i[edit update]
   resources :password_resets, only: %i[new create edit update]


### PR DESCRIPTION
## 概要
issue:#195 #196 #198
- 翻訳データの追加
  - locals/activemodel/ja.ymlを作成
 
- いいね一覧ページの実装
  -  headerリンクの修正
  - likes.html.erbの作成
 
- 各ユーザーの料理一覧ページの表示
  - 料理カードのアバターまたはニックネームに設置されたリンクをクリックすると、そのユーザーの料理一覧ページに遷移する 
    - アクションはusers#showであり、自分の料理一覧を取得するのと同じアクション&URL
    - 料理カードのリンクをクリックしたユーザーが
      - current_userなら、「自分の料理一覧」と表示(料理作者とクリックしたユーザーが一致)
      - そうでなければ、「◯◯の料理一覧」と表示させている