### PR TITLE
add:redis関係のgemの追加、session_storeをRedisに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'cssbundling-rails'
 gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
-gem 'redis', '~> 4.0'
+# gem 'redis', '~> 4.0'
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
@@ -57,6 +57,7 @@ gem 'rails-i18n'
 
 # 環境変数管理
 gem 'dotenv-rails'
+
 # 定数管理
 gem 'config'
 
@@ -74,6 +75,10 @@ gem 'carrierwave', '~> 3.0'
 
 # AWS接続用
 gem 'fog-aws'
+
+# Redis
+gem "redis", "~> 4.8.1", "< 5" # redis4系でないとactionpackが動かない
+gem 'redis-actionpack'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,15 @@ GEM
     rake (13.0.6)
     rbs (2.8.4)
     redis (4.8.1)
+    redis-actionpack (5.3.0)
+      actionpack (>= 5, < 8)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-rack (2.1.4)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.9.2)
+      redis (>= 4, < 6)
     regexp_parser (2.8.0)
     reline (0.3.4)
       io-console (~> 0.5)
@@ -433,7 +442,8 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
   rails-i18n
-  redis (~> 4.0)
+  redis (~> 4.8.1, < 5)
+  redis-actionpack
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/views/dishes/result.html.erb
+++ b/app/views/dishes/result.html.erb
@@ -118,14 +118,3 @@
     </div>
   </div>
 </div>
-<a
-  tabindex="0"
-  class="btn btn-lg btn-danger"
-  role="button"
-  data-mdb-toggle="popover"
-  data-mdb-trigger="focus"
-  title="Dismissible popover"
-  data-mdb-content="And here's some amazing content. It's very engaging. Right?"
->
-  Dismissible popover
-</a>

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,4 @@
+require 'redis'
+
+# gem 'redis'により、Redisクラスが使えるようになる
+REDIS = Redis.new(url: ENV.fetch('UPSTASH_REDIS_URL',ENV['REDIS_URL']))

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,6 @@
+AIOryouriNaming::Application.config.session_store :redis_store,
+  servers: ["redis://localhost:6379/0/session"],
+  expire_after: 90.minutes,
+  key: "_my_application_session",
+  threadsafe: true
+  # secure: true

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 AIOryouriNaming::Application.config.session_store :redis_store,
-  servers: ["redis://localhost:6379/0/session"],
+  servers: ENV.fetch('UPSTASH_REDIS_URL',ENV['REDIS_URL']), # 本番環境はUPSTASH_REDIS_URLにアクセス
   expire_after: 90.minutes,
-  key: "_my_application_session",
-  threadsafe: true
-  # secure: true
+  key: ENV['MY_APP_SESSION'],
+  threadsafe: true,
+  secure: Rails.env.production? # 開発・テスト環境はHTTPSを使用しないため、無効にする

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,6 +44,7 @@ ja:
       generate: 'AIに名前をつけてもらう'
     create:
       fail: '名前をつけられませんでした'
+      limit: 'AIくんが疲れちゃって、1日3回までしか使えません...ごめんね'
     show:
     update:
       success: '更新しました'

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,3 @@
+serialized_data = "\x04\b{\aI\"\x10_csrf_token\x06:\x06EFI\"066EeFS5cOelfLn04a7pHgiVQby3GcriVtVBYUL0_5bM\x06;\x00FI\"\x0cuser_id\x06;\x00FI\"\a84\x06;\x00F"
+deserialized_data = Marshal.load(serialized_data)
+puts deserialized_data

--- a/test.rb
+++ b/test.rb
@@ -1,3 +1,0 @@
-serialized_data = "\x04\b{\aI\"\x10_csrf_token\x06:\x06EFI\"066EeFS5cOelfLn04a7pHgiVQby3GcriVtVBYUL0_5bM\x06;\x00FI\"\x0cuser_id\x06;\x00FI\"\a84\x06;\x00F"
-deserialized_data = Marshal.load(serialized_data)
-puts deserialized_data


### PR DESCRIPTION
## 概要
issue:#10
- `gem 'redis'`, `gem 'redis-actionpack'`の導入。
- `config/initialize/session_store.rb`を作成し、セッション管理をCookieStoreからRedisに変更。
- 本番環境では、Upstashを使うように設定。
- 料理名生成機能の回数制限のためのメソッド`check_usage_count`を`dishes_controller`に定義。