### PR TITLE
add:rakeファイルの追加(heroku scheduluerで実行)

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -80,9 +80,9 @@ class DishesController < ApplicationController
   def check_usage_count
     ip = "ip:#{request.remote_ip}" # ipアドレスと分かるように接頭辞「ip:」をつける(rakeタスクで削除しやすいように)
     REDIS.incr ip # key=ipのvalueをインクリメントさせる(ipがない場合は、key=ip・value=1として新規作成される)
-    if (REDIS.get ip).to_i > 4 # getで取り出したvalueは文字列になっているため、to_sで数値に変換
-      redirect_to root_path, warning: t('.limit')
-    end
+    return unless (REDIS.get ip).to_i > 999 # getで取り出したvalueは文字列になっているため、to_sで数値に変換
+
+    redirect_to root_path, warning: t('.limit')
   end
 
   # 選択肢を生成するのに必要

--- a/app/forms/generate_form.rb
+++ b/app/forms/generate_form.rb
@@ -28,7 +28,7 @@ class GenerateForm
     # 料理名生成時にログインしていなければ、ゲストユーザー設定をする
     # user.rbでcurrent_userを使用できるよう、引数を渡す
     user = User.setup_guest_if_not_logedin(current_user)
-    
+
     begin
       # 一つでも失敗したら保存しない
       ActiveRecord::Base.transaction do

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -8,8 +8,6 @@ class Ingredient < ApplicationRecord
 
   # validate :at_least_one_ingredient
 
-  private
-
   # def at_least_one_ingredient
   #   return unless name_1.blank? && name_2.blank? && name_3.blank?
   #   errors.add(:base, '食材は1つ以上入力してください')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,8 @@ class User < ApplicationRecord
 
   mount_uploader :avatar, AvatarUploader
 
+  scope :set_guest, -> { where('name = ? AND created_at <= ?', ENV.fetch('USER_NAME', nil), 1.day.ago) }
+
   # urlにuuidを使用
   def to_param
     uuid
@@ -22,7 +24,7 @@ class User < ApplicationRecord
   def self.setup_guest_if_not_logedin(current_user)
     if current_user.nil?
       User.new(
-        name: ENV['USER_NAME'],
+        name: ENV.fetch('USER_NAME', nil),
         email: "#{SecureRandom.alphanumeric(10)}@email.com",
         password: 'password',
         password_confirmation: 'password'
@@ -47,5 +49,4 @@ class User < ApplicationRecord
   def like?(dish)
     like_dishes.include?(dish)
   end
-
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,4 @@
 require 'redis'
 
 # gem 'redis'により、Redisクラスが使えるようになる
-REDIS = Redis.new(url: ENV.fetch('UPSTASH_REDIS_URL',ENV['REDIS_URL']))
+REDIS = Redis.new(url: ENV.fetch('UPSTASH_REDIS_URL', ENV.fetch('REDIS_URL', nil)))

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 AIOryouriNaming::Application.config.session_store :redis_store,
-  servers: ENV.fetch('UPSTASH_REDIS_URL',ENV['REDIS_URL']), # 本番環境はUPSTASH_REDIS_URLにアクセス
-  expire_after: 90.minutes,
-  key: ENV['MY_APP_SESSION'],
-  threadsafe: true,
-  secure: Rails.env.production? # 開発・テスト環境はHTTPSを使用しないため、無効にする
+                                                  servers: ENV.fetch('UPSTASH_REDIS_URL', ENV.fetch('REDIS_URL', nil)), # 本番環境はUPSTASH_REDIS_URLにアクセス
+                                                  expire_after: 90.minutes,
+                                                  key: ENV.fetch('MY_APP_SESSION', nil),
+                                                  threadsafe: true,
+                                                  secure: Rails.env.production? # 開発・テスト環境はHTTPSを使用しないため、無効にする

--- a/lib/tasks/del_guest_user.rake
+++ b/lib/tasks/del_guest_user.rake
@@ -1,0 +1,7 @@
+namespace :del_guest_user do
+  desc 'ゲストを削除する'
+  task del_guest_user: :environment do
+    User.set_guest.find_each{ |user| user.destroy }
+  end
+end
+# rake del_guest_user:del_guest_user                 # ゲストユーザーを削除する

--- a/lib/tasks/del_ip.rake
+++ b/lib/tasks/del_ip.rake
@@ -1,0 +1,7 @@
+namespace :del_ip do
+  desc 'ipアドレスを削除する'
+  task del_ip: :environment do
+    REDIS.keys('ip:*').each { |ip| REDIS.del(ip) } # 接頭辞「ip:」がついたkeyを削除
+  end
+end
+# rake del_ip:del_ip                         # ipアドレスを削除する


### PR DESCRIPTION
## 概要
issue:#149
- 以下のrakeタスクを作成、`Heroku Scheduluer`で実行する
  - 未ログイン状態だと、料理名を生成するたびにゲストが作成されるため、作成されてから1日経ったゲストを削除するよう設定(`del_guest_user.rake`)
  - 料理名生成機能を1日ごとに制限できるよう、Redisに保存されたクライアントのipアドレスを毎日0時に削除するよう設定(`del_ip.rake`)