### PR TITLE
add:自分の料理一覧ページ用のURLを設定

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(uuid: params[:uuid])
-    @dishes = @user.dishes.order(created_at: :DESC).page(params[:page])
+    @dishes = @user.dishes.published.order(created_at: :DESC).page(params[:page])
   end
 
   def new
@@ -19,6 +19,10 @@ class UsersController < ApplicationController
       flash.now[:warning] = t('.fail')
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def my_dishes
+    @dishes = current_user.dishes.order(created_at: :DESC).page(params[:page])
   end
 
   private

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="card-body pt-0">
       <%# 今、自分の料理一覧ページにいる且つ「公開中」 =>trueで 「公開中」マークつける %>
-      <% if current_page?(user_path(dish.user.uuid)) && dish.published? %>
+      <% if current_page?(user_path(current_user.uuid)) && dish.published? %>
         <%= render partial: 'dishes/published' %>
       <% end %>
       <%# 料理名 %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
           <%= image_tag current_user.avatar.url , class: 'rounded-circle border border-3 avatar_img' %>
         </li>
         <li>
-          <%= link_to user_path(current_user.uuid), class:'header-dropdown-item dropdown-item' do %>
+          <%= link_to my_dishes_users_path, class:'header-dropdown-item dropdown-item' do %>
             <i class="fa-solid fa-utensils me-3 header-fontawesome"></i>
             <%= t('users.show.my_dishes') %>
           <% end%>

--- a/app/views/users/my_dishes.html.erb
+++ b/app/views/users/my_dishes.html.erb
@@ -1,4 +1,4 @@
-<h3 class='text-center fw-bold mt-5'><%= t('.someone_dishes', item: @user.name) %></h3>
+<h3 class='text-center fw-bold mt-5'><%= t('.title') %></h3>
 <div class="container">
   <div class="row">
     <% if @dishes.present? %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -24,6 +24,8 @@ ja:
       my_dishes: '自分の料理一覧'
       someone_dishes: '%{item}の料理一覧'
       no_data: '料理がありません'
+    my_dishes:
+      title: '自分の料理一覧'
 
   user_sessions:
     new:
@@ -61,6 +63,7 @@ ja:
       success: '投稿しました'
     likes:
       title: 'いいねした料理'
+      no_data: 'いいねした料理はありません'
 
   profiles:
     edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
 
-  resources :users, param: :uuid, only: %i[create show]
+  resources :users, param: :uuid, only: %i[create show] do
+    get 'my_dishes', on: :collection
+  end
   resources :dishes, param: :uuid do
     get 'result', on: :member
     patch 'publish', on: :member


### PR DESCRIPTION
## 概要
issue:#210
- 自分の料理一覧と各ユーザーの料理一覧を同じURLにしていたが、自分の料理一覧を独立させ、`users_my_dishes`というURLを新たに振った。(同じURLで処理を行った場合、viewへのコードの記載量が多くなり、わかりづらくなるため)