### PR TITLE
fix:OGP画像が表示されない問題を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= display_meta_tags(default_meta_tags) %>
-    <meta property="og:image" content="image_url('ogp.svg')">
   </head>
 
   <body>


### PR DESCRIPTION
## 概要
issue:#231
- headタグからog用のmetaタグの削除