### PR TITLE
fix:twitterとLineのSNSシェアのリンク先の修正

### DIFF
--- a/app/views/dishes/_share_result.html.erb
+++ b/app/views/dishes/_share_result.html.erb
@@ -1,13 +1,13 @@
 <h6 class='fw-bold text-center mb-3'>▼ 結果をみんなにシェアしよう ▼</h6>
 <div class="share-result d-flex justify-content-center">
   <div class="share-result-x me-3">
-    <%= link_to "https://twitter.com/share?url=#{ request.url }
+    <%= link_to "https://twitter.com/share?url=#{ result_dish_url(dish.uuid) }
         &text=🍳あなたが作った料理の名前は...%0a【#{ dish.dish_name }】%0a%23AIお料理ネーミング%0a",target: '_blank' do %>
     <i class="fa-brands fa-x-twitter x-share-button"></i>
     <% end %>
   </div>
     <div class="share-result-line me-3">
-      <%= link_to "https://social-plugins.line.me/lineit/share?url=#{ request.url }", id: 'line-share-button', target: "_blank" do %>
+      <%= link_to "https://social-plugins.line.me/lineit/share?url=#{ result_dish_url(dish.uuid) }", id: 'line-share-button', target: "_blank" do %>
         <i class="fa-brands fa-line line-share-button"></i>
       <% end %>
     </div>


### PR DESCRIPTION
## 概要
issue:#252
- 「公開する」ボタンを押した後に、SNSシェアをするとシェアするURLが`dishes/uuid/publish`となってしまい、存在しないURLを表示してしまっていた。原因は、SNSシェアで表示させるURLを`request.url `で取得していたためである。
- そこで、表示させるURLを`result_dish_url(dish.uuid)`と明示的に示すことでこの問題を解決した。