### PR TITLE
add:gem 'natto'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem "meta-tags"
 gem "redis", "~> 4.8.1", "< 5" # redis4系でないとactionpackが動かない
 gem 'redis-actionpack'
 
+# MeCab(形態素解析)
+gem  'natto'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    natto (1.2.0)
+      ffi (>= 1.9.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -440,6 +442,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web (~> 2.0)
   meta-tags
+  natto
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)

--- a/test.rb
+++ b/test.rb
@@ -1,0 +1,80 @@
+require 'natto'
+
+text10 = '豚スネ肉'
+ary10=[]
+
+natto = Natto::MeCab.new
+natto.parse(text10) do |n|
+  ary10 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+e = ary10.join(",")
+p e
+
+
+text11 = 'ねぎ'
+ary11=[]
+
+natto = Natto::MeCab.new
+natto.parse(text11) do |n|
+  ary11 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+f = ary11.join(",")
+p f
+
+
+text12 = 'トマト'
+ary12=[]
+
+natto = Natto::MeCab.new
+natto.parse(text12) do |n|
+  ary12 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+g =  ary12.join(",")
+p g
+
+ary0 = []
+ary0 << e.split(',')
+ary0 << f.split(',')
+ary0 << g.split(',')
+p ary0.flatten
+
+# ---------------------
+text1 = '牛スネ肉'
+ary1=[]
+
+natto = Natto::MeCab.new
+natto.parse(text1) do |n|
+  ary1 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+a = ary1.join(",")
+p a
+
+
+text2 = '玉ねぎ'
+ary2=[]
+
+natto = Natto::MeCab.new
+natto.parse(text2) do |n|
+  ary2 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+b = ary2.join(",")
+p b
+
+
+text3 = 'にんじん'
+ary3=[]
+
+natto = Natto::MeCab.new
+natto.parse(text3) do |n|
+  ary3 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+end
+c =  ary3.join(",")
+p c
+
+aryz = []
+aryz << a.split(',')
+aryz << b.split(',')
+aryz << c.split(',')
+p aryz.flatten
+
+p ((ary0.flatten & aryz.flatten).length.to_f/(ary0.flatten | aryz.flatten).length).round(3)


### PR DESCRIPTION
## 概要
issue:#260
- gem 'natto'を導入し、形態素解析を行うためのMeCabをRubyで操作できるようにした。