### PR TITLE
fix:DB設計の再構築

### DIFF
--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -10,11 +10,11 @@ class Dish < ApplicationRecord
   mount_uploader :dish_image, DishImageUploader
 
   belongs_to :user
-  belongs_to :ingredient
   belongs_to :seasoning
   belongs_to :texture
   belongs_to :category
   has_many :dishes_cooking_methods, dependent: :destroy
+  has_many :dish_ingredients, dependent: :destroy
   has_many :cooking_methods, through: :dishes_cooking_methods
   has_many :likes, dependent: :destroy
   enum state: { draft: 0, published: 1 }

--- a/app/models/dish_ingredient.rb
+++ b/app/models/dish_ingredient.rb
@@ -1,0 +1,6 @@
+class DishIngredient < ApplicationRecord
+  belongs_to :dish
+  belongs_to :ingredient
+
+  validates :dish_id, uniqueness: {scopr: :ingredient_id}
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,15 +1,3 @@
 class Ingredient < ApplicationRecord
-  has_one :dish, dependent: :destroy
-
-  # 食材は15文字以内
-  validates :name_1, length: { maximum: 15 }
-  validates :name_2, length: { maximum: 15 }
-  validates :name_3, length: { maximum: 15 }
-
-  # validate :at_least_one_ingredient
-
-  # def at_least_one_ingredient
-  #   return unless name_1.blank? && name_2.blank? && name_3.blank?
-  #   errors.add(:base, '食材は1つ以上入力してください')
-  # end
+  has_many :dish_ingredients, dependent: :destroy
 end

--- a/db/migrate/20230901141302_remove_column_to_dishes.rb
+++ b/db/migrate/20230901141302_remove_column_to_dishes.rb
@@ -1,0 +1,6 @@
+class RemoveColumnToDishes < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :dishes, column: :ingredient_id
+    remove_column :dishes, :ingredient_id, :string
+  end
+end

--- a/db/migrate/20230901151135_drop_ingredients.rb
+++ b/db/migrate/20230901151135_drop_ingredients.rb
@@ -1,0 +1,5 @@
+class DropIngredients < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :ingredients
+  end
+end

--- a/db/migrate/20230901152436_create_ingredients.rb
+++ b/db/migrate/20230901152436_create_ingredients.rb
@@ -1,9 +1,8 @@
 class CreateIngredients < ActiveRecord::Migration[7.0]
   def change
     create_table :ingredients do |t|
-      t.string :name_1
-      t.string :name_2
-      t.string :name_3
+      t.string :name, null: false
+      t.string :morphemes, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230902001213_create_dish_ingredients.rb
+++ b/db/migrate/20230902001213_create_dish_ingredients.rb
@@ -1,0 +1,11 @@
+class CreateDishIngredients < ActiveRecord::Migration[7.0]
+  def change
+    create_table :dish_ingredients do |t|
+      t.references :dish, null: false, foreign_key: true
+      t.references :ingredient, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :dish_ingredients, [:dish_id, :ingredient_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_02_001213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,9 +28,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "dish_ingredients", force: :cascade do |t|
+    t.bigint "dish_id", null: false
+    t.bigint "ingredient_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dish_id", "ingredient_id"], name: "index_dish_ingredients_on_dish_id_and_ingredient_id", unique: true
+    t.index ["dish_id"], name: "index_dish_ingredients_on_dish_id"
+    t.index ["ingredient_id"], name: "index_dish_ingredients_on_ingredient_id"
+  end
+
   create_table "dishes", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "ingredient_id", null: false
     t.bigint "seasoning_id", null: false
     t.bigint "texture_id", null: false
     t.bigint "category_id", null: false
@@ -42,7 +51,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category_id"], name: "index_dishes_on_category_id"
-    t.index ["ingredient_id"], name: "index_dishes_on_ingredient_id"
     t.index ["seasoning_id"], name: "index_dishes_on_seasoning_id"
     t.index ["texture_id"], name: "index_dishes_on_texture_id"
     t.index ["user_id"], name: "index_dishes_on_user_id"
@@ -60,9 +68,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
   end
 
   create_table "ingredients", force: :cascade do |t|
-    t.string "name_1"
-    t.string "name_2"
-    t.string "name_3"
+    t.string "name", null: false
+    t.string "morphemes", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -95,7 +102,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_14_011927) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
-  add_foreign_key "dishes", "ingredients"
+  add_foreign_key "dish_ingredients", "dishes"
+  add_foreign_key "dish_ingredients", "ingredients"
   add_foreign_key "dishes", "users"
   add_foreign_key "dishes_cooking_methods", "cooking_methods"
   add_foreign_key "dishes_cooking_methods", "dishes"


### PR DESCRIPTION
## 概要
issue:#258
- DishesテーブルとIngredientsテーブルを多対多の関係に再設定を行なった。これにより中間テーブルDish_ingredientsテーブルを新設した。ER図は下記図のように修正される。
![スクリーンショット 2023-09-01 11 43 33](https://github.com/consolelogfuku/ai-oryouri-naming/assets/108031744/4fcb40e3-eac8-41d1-8533-bca051255c3a)
