### PR TITLE
fix:データベース再設計による影響を修正

### DIFF
--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -80,7 +80,7 @@ class DishesController < ApplicationController
   def check_usage_count
     ip = "ip:#{request.remote_ip}" # ipアドレスと分かるように接頭辞「ip:」をつける(rakeタスクで削除しやすいように)
     REDIS.incr ip # key=ipのvalueをインクリメントさせる(ipがない場合は、key=ip・value=1として新規作成される)
-    return unless (REDIS.get ip).to_i > 5 # getで取り出したvalueは文字列になっているため、to_sで数値に変換
+    return unless (REDIS.get ip).to_i > 100 # getで取り出したvalueは文字列になっているため、to_sで数値に変換
 
     redirect_to root_path, warning: t('.limit')
   end

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -14,8 +14,9 @@ class Dish < ApplicationRecord
   belongs_to :texture
   belongs_to :category
   has_many :dishes_cooking_methods, dependent: :destroy
-  has_many :dish_ingredients, dependent: :destroy
   has_many :cooking_methods, through: :dishes_cooking_methods
+  has_many :dishes_ingredients, dependent: :destroy
+  has_many :ingredients, through: :dishes_ingredients
   has_many :likes, dependent: :destroy
   enum state: { draft: 0, published: 1 }
 
@@ -39,7 +40,7 @@ class Dish < ApplicationRecord
     * If any of the main ingredients or points provided by the user are not suitable as food, please respond with '食べられる食材で料理してほしいな...'
 
     ## User input
-    主な食材:#{ingredient.name_1},#{ingredient.name_2},#{ingredient.name_3}
+    主な食材:#{ingredients.pluck(:name).join(',')}
     調理法:#{cooking_methods.pluck(:name).join(',')}
     味付け: #{seasoning.name}
     食感:#{texture.name}

--- a/app/models/dish_ingredient.rb
+++ b/app/models/dish_ingredient.rb
@@ -1,6 +1,0 @@
-class DishIngredient < ApplicationRecord
-  belongs_to :dish
-  belongs_to :ingredient
-
-  validates :dish_id, uniqueness: {scopr: :ingredient_id}
-end

--- a/app/models/dishes_ingredient.rb
+++ b/app/models/dishes_ingredient.rb
@@ -1,0 +1,6 @@
+class DishesIngredient < ApplicationRecord
+  belongs_to :dish
+  belongs_to :ingredient
+
+  validates :dish_id, uniqueness: {scope: :ingredient_id}
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,3 +1,7 @@
 class Ingredient < ApplicationRecord
-  has_many :dish_ingredients, dependent: :destroy
+  has_many :dishes_ingredients, dependent: :destroy
+  has_many :dishes, through: :dishes_ingredients
+
+  validates :name, presence: true, uniqueness: true, length: { maximum: 15 }
+  validates :morphemes, presence: true, uniqueness: true
 end

--- a/app/views/dishes/_result.html.erb
+++ b/app/views/dishes/_result.html.erb
@@ -29,34 +29,25 @@
       <div class="col-md-6 mx-auto card-form-content py-4 px-4 mt-4 mb-5 shadow">
         <%# 食材 %>
         <%= Ingredient.model_name.human %>
-        <div class="row mb-4">
-          <div class="col-md-4 mt-2">
-            <%# 要素がない場合、cssのborderを表示させたくないため、条件分岐させる%>
-            <% if dish.ingredient.name_1.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= dish.ingredient.name_1 %></div>
-            <% end %>
-          </div>
-          <div class="col-md-4 mt-2">
-            <% if dish.ingredient.name_2.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= dish.ingredient.name_2 %></div>
-            <% end %>
-          </div>
-          <div class="col-md-4 mt-2">
-            <% if dish.ingredient.name_3.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= dish.ingredient.name_3 %></div>
-            <% end %>
-          </div>
+          <div class="row mb-4">
+          <% dish.ingredients.each do |ingredient| %>
+            <div class="col-md-4 mt-2">
+              <div class="result-dish-content py-1 ps-2">
+                <%= ingredient.name %>
+              </div>
+            </div>
+          <% end %>
         </div>
         <%# 調理法 %>
         <%= CookingMethod.model_name.human %>
         <div class="row mb-4">
-            <% dish.cooking_methods.each do |cooking_method| %>
-              <div class="col-md-4 mt-2">
-                <div class="result-dish-content py-1 ps-2">
-                  <%= cooking_method.name %>
-                </div>
+          <% dish.cooking_methods.each do |cooking_method| %>
+            <div class="col-md-4 mt-2">
+              <div class="result-dish-content py-1 ps-2">
+                <%= cooking_method.name %>
               </div>
-            <% end %>
+            </div>
+          <% end %>
         </div>
         <%# 味付け %>
         <%= Seasoning.model_name.human %>

--- a/app/views/dishes/new.html.erb
+++ b/app/views/dishes/new.html.erb
@@ -43,13 +43,13 @@
           <%= Ingredient.model_name.human %>
           <div class="row mb-4">
             <div class="col-md-4 mt-3">
-              <%= f.text_field :name_1 ,class:'form-control', placeholder: '残業終わりに買ったやきとり' %>
+              <%= f.text_field :name_1, class:'form-control', placeholder: '焼き鳥の残り' %>
             </div>
             <div class="col-md-4 mt-3">
-              <%= f.text_field :name_2, class:'form-control', placeholder: 'ネギ'%>
+              <%= f.text_field :name_2, class:'form-control', placeholder: 'なす'%>
             </div>
             <div class="col-md-4 mt-3">
-              <%= f.text_field :name_3, class:'form-control', placeholder: 'たまご' %>
+              <%= f.text_field :name_3, class:'form-control', placeholder: 'しょうが' %>
             </div>
             <div class="form-text">※1つ以上入力必須、各15文字以内で入力してください。</div>
           </div>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -8,33 +8,24 @@
         <%# 食材 %>
         <%= Ingredient.model_name.human %>
         <div class="row mb-4">
-          <div class="col-md-4 mt-2">
-            <%# 要素がない場合、cssのborderを表示させたくないため、条件分岐させる%>
-            <% if @dish.ingredient.name_1.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_1 %></div>
-            <% end %>
-          </div>
-          <div class="col-md-4 mt-2">
-            <% if @dish.ingredient.name_2.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_2 %></div>
-            <% end %>
-          </div>
-          <div class="col-md-4 mt-2">
-            <% if @dish.ingredient.name_3.present? %>
-              <div class="result-dish-content py-1 ps-2"><%= @dish.ingredient.name_3 %></div>
-            <% end %>
-          </div>
+          <% @dish.ingredients.each do |ingredient| %>
+            <div class="col-md-4 mt-2">
+              <div class="result-dish-content  py-1 ps-2">
+                <%= ingredient.name %>
+              </div>
+            </div>
+          <% end %>
         </div>
         <%# 調理法 %>
         <%= CookingMethod.model_name.human %>
         <div class="row mb-4">
-            <% @dish.cooking_methods.each do |cooking_method| %>
-              <div class="col-md-4 mt-2">
-                <div class="result-dish-content  py-1 ps-2">
-                  <%= cooking_method.name %>
-                </div>
+          <% @dish.cooking_methods.each do |cooking_method| %>
+            <div class="col-md-4 mt-2">
+              <div class="result-dish-content  py-1 ps-2">
+                <%= cooking_method.name %>
               </div>
-            <% end %>
+            </div>
+          <% end %>
         </div>
         <%# 味付け %>
         <%= Seasoning.model_name.human %>

--- a/db/migrate/20230902010719_change_column_to_ingredients.rb
+++ b/db/migrate/20230902010719_change_column_to_ingredients.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToIngredients < ActiveRecord::Migration[7.0]
+  def change
+    add_index :ingredients, :name, unique: true
+    add_index :ingredients, :morphemes, unique: true
+  end
+end

--- a/db/migrate/20230902011834_change_dish_ingredients_to_dishes_ingredients.rb
+++ b/db/migrate/20230902011834_change_dish_ingredients_to_dishes_ingredients.rb
@@ -1,0 +1,5 @@
+class ChangeDishIngredientsToDishesIngredients < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :dish_ingredients, :dishes_ingredients
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_02_001213) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_02_011834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,16 +26,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_001213) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "dish_ingredients", force: :cascade do |t|
-    t.bigint "dish_id", null: false
-    t.bigint "ingredient_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["dish_id", "ingredient_id"], name: "index_dish_ingredients_on_dish_id_and_ingredient_id", unique: true
-    t.index ["dish_id"], name: "index_dish_ingredients_on_dish_id"
-    t.index ["ingredient_id"], name: "index_dish_ingredients_on_ingredient_id"
   end
 
   create_table "dishes", force: :cascade do |t|
@@ -67,11 +57,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_001213) do
     t.index ["dish_id"], name: "index_dishes_cooking_methods_on_dish_id"
   end
 
+  create_table "dishes_ingredients", force: :cascade do |t|
+    t.bigint "dish_id", null: false
+    t.bigint "ingredient_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dish_id", "ingredient_id"], name: "index_dishes_ingredients_on_dish_id_and_ingredient_id", unique: true
+    t.index ["dish_id"], name: "index_dishes_ingredients_on_dish_id"
+    t.index ["ingredient_id"], name: "index_dishes_ingredients_on_ingredient_id"
+  end
+
   create_table "ingredients", force: :cascade do |t|
     t.string "name", null: false
     t.string "morphemes", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["morphemes"], name: "index_ingredients_on_morphemes", unique: true
+    t.index ["name"], name: "index_ingredients_on_name", unique: true
   end
 
   create_table "likes", force: :cascade do |t|
@@ -102,11 +104,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_02_001213) do
     t.index ["uuid"], name: "index_users_on_uuid", unique: true
   end
 
-  add_foreign_key "dish_ingredients", "dishes"
-  add_foreign_key "dish_ingredients", "ingredients"
   add_foreign_key "dishes", "users"
   add_foreign_key "dishes_cooking_methods", "cooking_methods"
   add_foreign_key "dishes_cooking_methods", "dishes"
+  add_foreign_key "dishes_ingredients", "dishes"
+  add_foreign_key "dishes_ingredients", "ingredients"
   add_foreign_key "likes", "dishes"
   add_foreign_key "likes", "users"
 end

--- a/test.rb
+++ b/test.rb
@@ -1,6 +1,6 @@
 require 'natto'
 
-text10 = '豚スネ肉'
+text10 = 'たまご'
 ary10=[]
 
 natto = Natto::MeCab.new
@@ -10,71 +10,81 @@ end
 e = ary10.join(",")
 p e
 
+class String
+  def to_hira
+   self.tr('ア-ン', 'あ-ん')
+  end
+ end
+ puts "アンパンマン".to_hira
 
-text11 = 'ねぎ'
-ary11=[]
+ require 'nkf'
+ name = 'マグロ'
+p NKF.nkf("--hiragana -w", name) #=> "アイウエオ"
 
-natto = Natto::MeCab.new
-natto.parse(text11) do |n|
-  ary11 << n.surface unless n.surface.empty? # 空白が混じるため除外する
-end
-f = ary11.join(",")
-p f
+# text11 = 'ねぎ'
+# ary11=[]
 
-
-text12 = 'トマト'
-ary12=[]
-
-natto = Natto::MeCab.new
-natto.parse(text12) do |n|
-  ary12 << n.surface unless n.surface.empty? # 空白が混じるため除外する
-end
-g =  ary12.join(",")
-p g
-
-ary0 = []
-ary0 << e.split(',')
-ary0 << f.split(',')
-ary0 << g.split(',')
-p ary0.flatten
-
-# ---------------------
-text1 = '牛スネ肉'
-ary1=[]
-
-natto = Natto::MeCab.new
-natto.parse(text1) do |n|
-  ary1 << n.surface unless n.surface.empty? # 空白が混じるため除外する
-end
-a = ary1.join(",")
-p a
+# natto = Natto::MeCab.new
+# natto.parse(text11) do |n|
+#   ary11 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+# end
+# f = ary11.join(",")
+# p f
 
 
-text2 = '玉ねぎ'
-ary2=[]
+# text12 = 'トマト'
+# ary12=[]
 
-natto = Natto::MeCab.new
-natto.parse(text2) do |n|
-  ary2 << n.surface unless n.surface.empty? # 空白が混じるため除外する
-end
-b = ary2.join(",")
-p b
+# natto = Natto::MeCab.new
+# natto.parse(text12) do |n|
+#   ary12 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+# end
+# g =  ary12.join(",")
+# p g
+
+# ary0 = []
+# ary0 << e.split(',')
+# ary0 << f.split(',')
+# ary0 << g.split(',')
+# p ary0.flatten
+
+# # ---------------------
+# text1 = '牛スネ肉'
+# ary1=[]
+
+# natto = Natto::MeCab.new
+# natto.parse(text1) do |n|
+#   ary1 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+# end
+# a = ary1.join(",")
+# p a
 
 
-text3 = 'にんじん'
-ary3=[]
+# text2 = '玉ねぎ'
+# ary2=[]
 
-natto = Natto::MeCab.new
-natto.parse(text3) do |n|
-  ary3 << n.surface unless n.surface.empty? # 空白が混じるため除外する
-end
-c =  ary3.join(",")
-p c
+# natto = Natto::MeCab.new
+# natto.parse(text2) do |n|
+#   ary2 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+# end
+# b = ary2.join(",")
+# p b
 
-aryz = []
-aryz << a.split(',')
-aryz << b.split(',')
-aryz << c.split(',')
-p aryz.flatten
 
-p ((ary0.flatten & aryz.flatten).length.to_f/(ary0.flatten | aryz.flatten).length).round(3)
+# text3 = 'にんじん'
+# ary3=[]
+
+# natto = Natto::MeCab.new
+# natto.parse(text3) do |n|
+#   ary3 << n.surface unless n.surface.empty? # 空白が混じるため除外する
+# end
+# c =  ary3.join(",")
+# p c
+
+# aryz = []
+# aryz << a.split(',')
+# aryz << b.split(',')
+# aryz << c.split(',')
+# p aryz.flatten
+
+# p ((ary0.flatten & aryz.flatten).length.to_f/(ary0.flatten | aryz.flatten).length).round(3)


### PR DESCRIPTION
## 概要
issue:#259
- `generate_form.rb`
  - ユーザーがフォームに入力した値をingredientsテーブルのnameカラムに保存する際に、合わせて形態素解析した結果をmorphemesカラムに保存するように設定。
- `dishes/new.html.erb`、`_result.html.erb`、`dishes/show.html.erb`の修正を行なった。
- `dish.rb`、`ingredient.rb`、`dishes_ingredients.rb`にそれぞれ関連を定義。必要な箇所にバリデーションを設定した。