### PR TITLE
improve:料理名生成結果画面と料理詳細画面のこだわりポイントの表示領域を広げた

### DIFF
--- a/app/views/dishes/_result.html.erb
+++ b/app/views/dishes/_result.html.erb
@@ -80,7 +80,7 @@
         <% if dish.point.present? %>
           <%= Dish.human_attribute_name(:point) %>
           <div class="row mb-4">
-            <div class="col-md-6 mt-2">
+            <div class="col-md-7 mt-2">
               <div class="result-dish-content py-1 ps-2">
                 <%= dish.point %>
               </div>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -58,7 +58,7 @@
         <% if @dish.point.present? %>
           <%= Dish.human_attribute_name(:point) %>
           <div class="row mb-4">
-            <div class="col-md-6 mt-2">
+            <div class="col-md-7 mt-2">
               <div class="result-dish-content  py-1 ps-2">
                 <%= @dish.point %>
               </div>

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -4,5 +4,5 @@ ja:
       generate_form:
     attributes:
       generate_form:
-        point: 'ポイント'
+        point: 'こだわりポイント'
         dish_image: '料理写真'


### PR DESCRIPTION
## 概要
issue:#262
- こだわりポイントを20文字入力すると、表示が2行になってしまっていたので、一行で表示できるように表示領域を広げた。