### PR TITLE
add:Heroku上でMeCabを使えるように設定

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,4 @@
+mecab
+libmecab-dev
+mecab-ipadic
+mecab-ipadic-utf8

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem "redis", "~> 4.8.1", "< 5" # redis4系でないとactionpackが動かない
 gem 'redis-actionpack'
 
 # MeCab(形態素解析)
+gem 'mecab', '0.996'
 gem  'natto'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    mecab (0.996)
     meta-tags (2.18.0)
       actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
@@ -441,6 +442,7 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   letter_opener_web (~> 2.0)
+  mecab (= 0.996)
   meta-tags
   natto
   pg (~> 1.1)


### PR DESCRIPTION
## 概要
issue:#267
- `heroku-buildpack-apt`を使用してMeCab関連のパッケージをHeroku上にインストールするよう設定した。