### PR TITLE
improve:flashをtoastに変更した

### DIFF
--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -452,3 +452,11 @@
   color: #3cc755;
   z-index: 4;
 }
+
+// トースト
+#flashes {
+  position: sticky;
+  top: 87px;
+  left: 5px;
+  z-index: 10;
+}

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -57,7 +57,7 @@ class DishesController < ApplicationController
     @dish = Dish.find_by(uuid: params[:uuid])
     @dish.update!(state: 'published')
     flash.now[:success] = t('.success')
-    render :result, status: :unprocessable_entity
+    # render :result, status: :unprocessable_entity
   end
 
   # いいね一覧を取得

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,13 @@ module ApplicationHelper
       }
     }
   end
+
+  # Toastの表示設定
+  def icon(icon_name)
+    tag.i(class: ['bi', "bi-#{icon_name}"])
+  end
+
+  def icon_with_text(icon_name, text)
+    tag.span(icon(icon_name), class: 'me-2') + tag.span(text)
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ToastController from "./toast_controller"
+application.register("toast", ToastController)

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+import { Toast } from "bootstrap"
+
+// Connects to data-controller="toast"
+export default class extends Controller {
+  connect() {
+    // Toastを生成
+    const toast = new Toast(this.element)
+    // Toastを表示
+    toast.show()
+  }
+}

--- a/app/views/dishes/publish.turbo_stream.erb
+++ b/app/views/dishes/publish.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.replace @dish do %>
+  <%= render partial: 'result', locals: { dish: @dish } %>
+<% end %>
+<%= turbo_stream.append 'flashes', partial: 'shared/flash_message' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,7 @@
       <%= render 'shared/before_login_header' %>
     <% end %>
     <%= render 'shared/flash_message' %>
+    <div id="flashes"></div>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,23 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>" role="alert"><%= message %></div>
+<%# 成功時のToast %>
+  <% if message_type.to_s == "success" %>
+    <div class="mb-2 toast hide border-success" data-controller="toast" id="flashes">
+      <div class="toast-header text-success">
+        <strong class="me-auto"><%= icon_with_text("check-circle", "成功") %></strong>
+        <button class="btn-close" data-bs-dismiss="toast"></button>
+      </div>
+      <div class="toast-body"><%= message %></div>
+    </div>
+  <% end %>
+
+  <%# エラー時のToast %>
+  <% if message_type.to_s == "warning" %>
+    <div class="mb-2 toast hide border-danger position-sticky" data-controller="toast" id="flashes">
+      <div class="toast-header text-danger">
+        <strong class="me-auto"><%= icon_with_text("exclamation-circle", "エラー") %></strong>
+        <button class="btn-close" data-bs-dismiss="toast"></button>
+      </div>
+      <div class="toast-body"><%= message %></div>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
## 概要
issue:#236
- FlashをすべてToastに変更
- また料理名生成結果画面で、料理を公開したときに表示させるToastをTurboを使って実装した。それにより、公開したときに画面が再度読み込まれないため、画面のスクロール位置を公開ボタンを押した場所で維持することができた。