### PR TITLE
fix:application.jsからpreview.jsを削除

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,5 +3,4 @@ import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
 import "@fortawesome/fontawesome-free/js/all";
-import './preview.js'
 import './check_count.js'


### PR DESCRIPTION
## 概要
issue:#283
- Stimulus導入前に使用していた、`preview.js`を`application.js`に読み込ませていたため、エラーが発生していた。
  - `preview.js`自体は既に削除済み。