### PR TITLE
fix:herokuのbuildエラーの解消

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -7,5 +7,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("UPSTASH_REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: AI_Oryouri_Naming_production


### PR DESCRIPTION
## 概要
issue:#285
- cable.ymlで、本番環境のRedisの環境変数を設定していなかったため、buildエラーが発生した。