### PR TITLE
fix:loading中に回転している画像のファイル名が異なっていたため修正

### DIFF
--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,5 +1,5 @@
 <div class='mask hidden' data-behavior='hidden'></div>
 <div class='loadingModal hidden shadow text-center' data-behavior='hidden'>
   <h3 class="fw-bold mb-4">考え中です...</h3>
-  <%= image_tag 'spin_robot', size: '180x180', class: 'mx-auto spin-robot' %>
+  <%= image_tag 'spin_robot.svg', size: '180x180', class: 'mx-auto spin-robot' %>
 </div>


### PR DESCRIPTION
## 概要
issue:#288
- image_tagの中で、ファイル名を`spin_robot`としていたため、`spin_robot.svg`に修正した。(herokuのbuildエラーが起きていたため)