### PR TITLE
fix:ActionCableのStreamを各ユーザーごとに一意になるように修正

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,4 +1,11 @@
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    # ip_address という識別子を使って、接続を一意に識別する(ip_addressという値は、チャネル内で使用可能)
+    identified_by :ip_address
+
+    # connectメソッドはWebSocket接続時に自動的に呼び出される特別なメソッド(初期化)
+    def connect
+      self.ip_address = request.remote_ip
+    end
   end
 end

--- a/app/channels/loading_channel.rb
+++ b/app/channels/loading_channel.rb
@@ -1,6 +1,6 @@
 class LoadingChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "loading_channel"
+    stream_from "loading_channel_#{ip_address}" # ip_addressはconnectionで定義した識別子
   end
 
   def unsubscribed

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -23,7 +23,8 @@ class DishesController < ApplicationController
 
   def create
     @generate_form = GenerateForm.new(generate_params)
-    @dish = @generate_form.save_dish(current_user)
+    ip_address = request.remote_ip
+    @dish = @generate_form.save_dish(current_user, ip_address)
     if @dish.persisted? # DBに保存できているかで分岐させる
       redirect_to result_dish_path(@dish.uuid)
     else

--- a/app/forms/generate_form.rb
+++ b/app/forms/generate_form.rb
@@ -26,7 +26,7 @@ class GenerateForm
   validates :category_id, presence: true
   validates :point, length: { maximum: 20 }
 
-  def save_dish(current_user)
+  def save_dish(current_user, ip_address)
     # 料理名生成時にログインしていなければ、ゲストユーザー設定をする
     # user.rbでcurrent_userを使用できるよう、引数を渡す
     user = User.setup_guest_if_not_logedin(current_user)
@@ -49,9 +49,9 @@ class GenerateForm
         cooking_methods.each do |cooking_method|
           @dish.cooking_methods << CookingMethod.find_by(name: cooking_method)
         end
-        if @dish.valid?
+        if @dish.valid? # バリデーションが通ったらすぐmodalを表示させる
           ActionCable.server.broadcast( # modal表示するためのメッセージをコンシューマーに送信
-            "loading_channel", { event: 'showLoadingModal' }
+            "loading_channel_#{ip_address}", { event: 'showLoadingModal' }
           )
         end
         @dish.save! # 保存できない場合は、例外を発生させて全ての処理をロールバックさせる(例外を発生させないと、処理がロールバックされず、DBに保存されてしまう)


### PR DESCRIPTION
## 概要
issue:#293
- ActionCableのStream名に各ユーザーのIPアドレスを含めることで、Streamの一意性を確保した。
  - この修正により、コンシューマーが誰か一人でも「料理名生成ボタン」を押したらモーダルが表示されるという現象はなくなり、「料理名生成ボタン」を押したコンシューマーのみにモーダルが表示される。