### PR TITLE
fix:modalが表示されないのは、Stream名にipアドレスを含めたことが原因か調査するために、ipアドレスをStream名から削除

### DIFF
--- a/app/channels/loading_channel.rb
+++ b/app/channels/loading_channel.rb
@@ -1,6 +1,6 @@
 class LoadingChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "loading_channel_#{ip_address}" # ip_addressはconnectionで定義した識別子
+    stream_from "loading_channel" # ip_addressはconnectionで定義した識別子
   end
 
   def unsubscribed

--- a/app/forms/generate_form.rb
+++ b/app/forms/generate_form.rb
@@ -51,7 +51,7 @@ class GenerateForm
         end
         if @dish.valid? # バリデーションが通ったらすぐmodalを表示させる
           ActionCable.server.broadcast( # modal表示するためのメッセージをコンシューマーに送信
-            "loading_channel_#{ip_address}", { event: 'showLoadingModal' }
+            "loading_channel", { event: 'showLoadingModal' }
           )
         end
         @dish.save! # 保存できない場合は、例外を発生させて全ての処理をロールバックさせる(例外を発生させないと、処理がロールバックされず、DBに保存されてしまう)


### PR DESCRIPTION
## 概要
issue:#295
