### PR TITLE
add:「似た料理」表示機能の実装

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -2,5 +2,6 @@
 @import 'custom/style.scss';
 @import 'custom/circles_animation.scss';
 @import 'custom/dish_card.scss';
+@import 'custom/similar_dish_modal.scss';
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';

--- a/app/assets/stylesheets/custom/similar_dish_modal.scss
+++ b/app/assets/stylesheets/custom/similar_dish_modal.scss
@@ -1,0 +1,74 @@
+// 似た料理モーダル(料理カード含む)とマスク
+
+// マスク
+.similar-dish-mask {
+  background-color: rgba(0, 0, 0, 0.4);
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 9;
+}
+
+// モーダル
+.similar-dish-modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  width: 80%;
+  @media (min-width: 576px) {
+    width: 40%;
+  }
+  @media (min-width: 992px) {
+    width: 30%;
+  }
+  transform: translate(-50%, -50%);
+  z-index: 10;
+}
+
+// 「似た料理」用の料理カード
+.similar-dish-card{
+  max-width: 100%;
+  
+  &-img-block {
+    width: 91%;
+    margin: 0 auto;
+    position: relative;
+    top: -20px;
+  }
+
+  &-img-block img{
+    border-radius:3px;
+    box-shadow:0 0 10px rgba(0,0,0,0.4);
+  }
+
+  &-title {
+    color: #424242 !important;
+    text-decoration: none;
+    border-bottom: 1px solid;
+  }
+  
+  &-title:hover {
+    opacity: 0.7;
+  }
+
+  &-link {
+    text-decoration: none;
+  }
+  
+  &-link:hover {
+    opacity: 0.7;
+  }
+
+  &-text {
+    color: #424242 !important;
+  }
+
+  &-avatar {
+    width: 70px;
+    height: 70px;
+    object-fit: cover;
+  }
+
+}

--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -540,6 +540,7 @@
   z-index: 20;
   border: solid 2px #7a7a7a;
   
+  // 画面が768px以上だったら要素を画面の中央から左に190pxの場所にボタンを配置
   @media (min-width: 768px) {
     left: calc(50% + 190px);
   }
@@ -565,3 +566,4 @@
     background-color: rgba(254, 220, 64, 1);
   }
 }
+

--- a/app/controllers/dishes_controller.rb
+++ b/app/controllers/dishes_controller.rb
@@ -52,6 +52,8 @@ class DishesController < ApplicationController
 
   def result
     @dish = Dish.find_by(uuid: params[:uuid])
+    # 作成した料理と似た料理を合わせて取得
+    @similar_dish = @dish.similar_dish
   end
 
   # ステータスを公開に変更
@@ -66,13 +68,6 @@ class DishesController < ApplicationController
   def likes
     @likes = current_user.like_dishes.includes(:user).order(created_at: :DESC).page(params[:page])
   end
-
-  # 似た料理表示
-  # def similar
-  #   @dish = Dish.find_by(uuid: params[:uuid])
-  #   # 一番ジャッカード係数の高い料理を取得
-  #   @similar_dish = @dish.similar_dish
-  # end
 
   private
 

--- a/app/javascript/controllers/similar_dish_controller.js
+++ b/app/javascript/controllers/similar_dish_controller.js
@@ -2,10 +2,19 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="similar-dish"
 export default class extends Controller {
+  static targets = [ 'mask', 'modal', 'button', 'buttonText' ]
 
   showModal(e) {
-    // const target = e.target
+    this.buttonTarget.setAttribute('data-action', 'click->similar-dish#closeModal');  // data-actionを変更
+    this.buttonTextTarget.textContent = '閉じる';
+    this.maskTarget.classList.remove('hidden');
+    this.modalTarget.classList.remove('hidden');
+  };
 
-    // alert('qq');
+  closeModal() {
+    this.buttonTarget.setAttribute('data-action', 'click->similar-dish#showModal');  // data-actionを元に戻す
+    this.buttonTextTarget.textContent = '似た料理を見る';
+    this.maskTarget.classList.add('hidden');
+    this.modalTarget.classList.add('hidden');
   };
 }

--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -39,7 +39,7 @@ class Dish < ApplicationRecord
     source = ingredients.map(&:morphemes)
 
     # DBに保存してある料理(公開済みのもののみ)の食材の形態素解析結果を配列に格納(target)し、比較元(source)とのジャッカード係数を求める
-    dishes = Dish.where(state: 'publish')
+    dishes = Dish.includes(:user, :ingredients).where(state: 'published')
     dishes.each do |dish|
       # 自分自身(source)とは比較しない
       next if dish == self
@@ -52,7 +52,6 @@ class Dish < ApplicationRecord
       union = source | target
       # ジャッカード係数を求める(少数第5位まで)
       jaccard_index = (intersection.length.to_f / union.length).round(5)
-
       next unless jaccard_index > highest
 
       # 一番大きいジャッカード係数をhighestに格納
@@ -60,7 +59,6 @@ class Dish < ApplicationRecord
       # 一番大きいジャッカード係数をもつdishを設定
       highest_dish = dish
     end
-
     highest_dish
   end
 

--- a/app/views/dishes/_result.html.erb
+++ b/app/views/dishes/_result.html.erb
@@ -23,7 +23,7 @@
   </div>
 </div>
 <h5 class="text-center py-4 bg-primary shadow-sm text-white mb-0 fw-bold">▼ あなたの料理情報 ▼</h5>
-<div class="card-form-bg-light-yellow px-3 pb-3">
+<div class="card-form-bg-light-yellow px-3 pb-3" data-controller='similar-dish'>
   <div class="container">
     <div class="row">
       <div class="col-md-6 mx-auto card-form-content py-4 px-4 mt-4 mb-5 shadow">
@@ -112,5 +112,7 @@
   </div>
   <%# 似ている料理ボタン %>
   <%= render partial: 'dishes/similar_dish_button', locals: { dish: dish } %>
+  <%# 似ている料理modal %>
+  <%= render partial: 'dishes/similar_dish_modal', locals: { similar_dish: similar_dish } %>
 </div>
 

--- a/app/views/dishes/_similar_dish_button.html.erb
+++ b/app/views/dishes/_similar_dish_button.html.erb
@@ -1,3 +1,3 @@
-  <%= link_to similar_dish_path(dish.uuid), class: "similar-dish-button px-3 py-3 text-center d-flex justify-content-center align-items-center", data: { action: 'click->similar_dish#showModal' } do %>
-  <p class='similar-dish-text m-0 fw-bold'>似た料理を見る</p>
-  <% end %>
+<%= button_tag 'similar_dish_path(dish.uuid)', class: "similar-dish-button px-3 py-3 text-center d-flex justify-content-center align-items-center", data: { action: 'click->similar-dish#showModal', target: 'similar-dish.button' } do %>
+  <p class='similar-dish-text m-0 fw-bold' data-similar-dish-target='buttonText'>似た料理を見る</p>
+<% end %>

--- a/app/views/dishes/_similar_dish_modal.html.erb
+++ b/app/views/dishes/_similar_dish_modal.html.erb
@@ -1,72 +1,23 @@
-<div class="board-background">
-  <div class="card-form-bg-none px-3">
-    <h3 class="fw-bold text-center pt-5 dish-title"><%= dish.dish_name %></h3>
-    <div class="text-center mt-5 my-4 result-dish-image "><%= image_tag dish.dish_image_url %></div>
-    <div class="container">
-      <div class="row">
-        <div class="col-md-6 mx-auto card-form-content py-4 px-4 mt-4 mb-5 shadow">
-          <%# 食材 %>
-          <%= Ingredient.model_name.human %>
-          <div class="row mb-4">
-            <% dish.ingredients.each do |ingredient| %>
-              <div class="col-md-4 mt-2">
-                <div class="result-dish-content  py-1 ps-2">
-                  <%= ingredient.name %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-          <%# 調理法 %>
-          <%= CookingMethod.model_name.human %>
-          <div class="row mb-4">
-            <% dish.cooking_methods.each do |cooking_method| %>
-              <div class="col-md-4 mt-2">
-                <div class="result-dish-content  py-1 ps-2">
-                  <%= cooking_method.name %>
-                </div>
-              </div>
-            <% end %>
-          </div>
-          <%# 味付け %>
-          <%= Seasoning.model_name.human %>
-          <div class="row mb-4">
-            <div class="col-md-4 mt-2">
-              <div class="result-dish-content py-1 ps-2">
-                <%= dish.seasoning.name %>
-              </div>
-            </div>
-          </div>
-          <%# 食感 %>
-          <%= Texture.model_name.human %>
-          <div class="row mb-4">
-            <div class="col-md-4 mt-2">
-              <div class="result-dish-content  py-1 ps-2">
-                <%= dish.texture.name %>
-              </div>
-            </div>
-          </div>
-          <%# カテゴリ %>
-          <%= Category.model_name.human %>
-          <div class="row mb-4">
-            <div class="col-md-4 mt-2">
-              <div class="result-dish-content  py-1 ps-2">
-                <%= dish.category.name %>
-              </div>
-            </div>
-          </div>
-          <%# ポイント(要素がない場合、表示させない) %>
-          <% if dish.point.present? %>
-            <%= Dish.human_attribute_name(:point) %>
-            <div class="row mb-4">
-              <div class="col-md-7 mt-2">
-                <div class="result-dish-content  py-1 ps-2">
-                  <%= dish.point %>
-                </div>
-              </div>
-            </div>
+<div class='similar-dish-mask hidden' data-similar-dish-target='mask' data-action='click->similar-dish#closeModal'></div>
+<div class="similar-dish-modal hidden" data-similar-dish-target='modal'>
+  <div class="card similar-dish-card">
+    <div class="similar-dish-card-img-block">
+      <%= image_tag similar_dish.dish_image_url, class:'card-img-top' %>
+    </div>
+    <div class="card-body pt-0">
+      <%# 料理名 %>
+      <h5 class="fw-bold"><%= link_to similar_dish.dish_name, dish_path(similar_dish.uuid), class:'similar-dish-card-title' %></h5>
+      <%# アバター、ニックネーム %>
+      <div class="d-flex align-items-center mt-3">
+        <div class="flex-grow-1 d-flex align-items-center">
+          <%= link_to user_path(similar_dish.user.uuid), class:'d-flex align-items-center similar-dish-card-link ' do %>
+            <%= image_tag similar_dish.user.avatar.url , class: 'rounded-circle border border-3 similar-dish-card-avatar' %>
+            <p class="similar-dish-card-text ms-3 mb-0"><%= similar_dish.user.name %></p>
           <% end %>
         </div>
       </div>
+      <%# 日付 %>
+      <p class="card-time text-end mb-0"><%= l similar_dish.created_at, format: :long, class:'text-right' %></p>
     </div>
   </div>
 </div>

--- a/app/views/dishes/result.html.erb
+++ b/app/views/dishes/result.html.erb
@@ -2,5 +2,5 @@
 <% if ['いたずらはやめて〜','食べられる食材で料理してほしいな...'].include?(@dish.dish_name) %>
   <%= render partial: 'failed_result', locals: { dish: @dish } %>
 <% else %>
-  <%= render partial: 'result', locals: { dish: @dish } %>
+  <%= render partial: 'result', locals: { dish: @dish, similar_dish: @similar_dish } %>
 <% end %>


### PR DESCRIPTION
## 概要
issue:#303
- 「似た料理」機能を料理名生成結果画面に実装した。以下処理の流れを記載。(「似た料理」は公開済みの料理からのみ選出)

1.  「似た料理」ボタンをクリック
2. 料理名生成時に取得した、似た料理をモーダルで表示(Stimulusで操作)
3. 「似た料理」ボタンが「閉じる」ボタンに変化&マスクの表示
4. 「閉じる」ボタンorマスクをクリックすると、モーダルが閉じる

- 実装のポイント
  - 当初は「似た料理」ボタンをクリックすると、料理の類似度計算を行い、「似た料理」をモーダルに表示してくれるように 実装を考えていた。
  - 実際の実装は、料理名生成時に合わせて`dishes_controller`の`results`メソッドで類似度計算を行い、その結果を`results.html.erb`に返すようにした。これにより容易にモーダルに「似た料理」の情報を渡すことができた。