### PR TITLE
fix:LINEログインボタン画像の拡張子が抜けていたため、herokuのbuildエラーが出ていた。

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -3,13 +3,13 @@ class OauthsController < ApplicationController
 
   # ユーザーをプロバイダに送る
   def oauth
-    session[:oauth_provider] = auth_params[:provider]
     login_at(auth_params[:provider])
   end
 
+  # ログイン認証時に呼ばれる
   def callback
     provider = auth_params[:provider]
-    if (@user = login_from(provider))
+    if (@user = login_from(provider)) # 既に一度ログインしたとこがある場合
       redirect_to root_path, success: t('.success')
     else
       @user = create_from(provider)

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -25,7 +25,7 @@
         <div class='border-bottom mt-4'></div>
         <div class="text-center mt-4">
           <%= link_to auth_at_provider_path(provider: :line) do %> 
-            <%= image_tag 'btn_login_base', size: '154x45', class: 'line-login-button' %>
+            <%= image_tag 'btn_login_base.png', size: '154x45', class: 'line-login-button' %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## 概要
issue:#312
- ログインボタンの拡張子`.png`のつけ忘れを修正