### PR TITLE
add:ModelSpecの追加とFactoryの修正

### DIFF
--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -37,7 +37,6 @@ class Dish < ApplicationRecord
 
     # 比較元の料理の食材の形態素解析結果を配列に格納する(source)
     source = ingredients.map(&:morphemes)
-
     # DBに保存してある料理(公開済みのもののみ)の食材の形態素解析結果を配列に格納(target)し、比較元(source)とのジャッカード係数を求める
     dishes = Dish.includes(:ingredients).where(state: 'published')
     dishes.each do |dish|
@@ -95,8 +94,8 @@ class Dish < ApplicationRecord
         temperature: 1.0
       }
     )
-    # レスポンスから料理名を取得(ダブルクオーテーションが含まれることがあるため、あらかじめ削除しておく)
-    self.dish_name = response.dig('choices', 0, 'message', 'content').gsub(/["「」]/, '')
+    # レスポンスから料理名を取得(シングル・ダブルクオーテーション、鉤括弧が含まれることがあるため、あらかじめ削除しておく)
+    self.dish_name = response.dig('choices', 0, 'message', 'content').gsub(/['"「」]/, '')
     save!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :like_dishes, through: :likes, source: :dish
 
   before_create -> { self.uuid = SecureRandom.uuid }
-  validates :name, presence: true, length: { maximum: 15 } # 20文字以内
+  validates :name, presence: true, length: { maximum: 15 } # 15文字以内
   validates :email, presence: true, uniqueness: true
   validates :password, length: { minimum: 8 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -18,15 +18,17 @@ ja:
         avatar: 'プロフィール画像'
       dish:
         id: 'ID'
+        seasoning: '味付け'
+        texture: '食感'
+        category: 'カテゴリー'
         dish_name: '料理名'
         point: 'こだわりポイント'
         dish_image: '料理写真'
         state: 'ステータス'
       ingredient:
         id: 'ID'
-        name_1: '食材1'
-        name_2: '食材2'
-        name_3: '食材3'
+        name: '食材'
+        morphemes: 形態素
       cooking_method:
         id: 'ID'
         name: '調理法'

--- a/spec/factories/dishes_ingredients.rb
+++ b/spec/factories/dishes_ingredients.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :dish_ingredient do
+  factory :dishes_ingredient do
     association :dish
     association :ingredient
   end

--- a/spec/factories/ingredients.rb
+++ b/spec/factories/ingredients.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
+  require 'tiny_segmenter' 
+
   factory :ingredient do
-    # あらかじめDBにデータを保存しているためFactoryの生成は不要
+    name {nil}
+    # 形態素解析
+    ts = TinySegmenter.new
+    # build(:ingredient, name: '◯◯')とした場合(dishの関連として生成しなかった場合)、形態素解析できるようコードを書いておく
+    morphemes {ts.segment(name).join(',')}
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     sequence(:email) {|n| "user_#{n}@gmail"}
     password {"password1234"}
     password_confirmation {"password1234"}
-    avatar {Rack::Test::UploadedFile.new(File.join(Rails.root, 'spec/factories/test.png'))} # テスト環境でファイルのアップロードをシミュレートする
+    avatar {nil} # テスト環境でファイルのアップロードをシミュレートする
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # 擬似テーブルのため、テストなし
 end

--- a/spec/models/cooking_method_spec.rb
+++ b/spec/models/cooking_method_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe CookingMethod, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # すでにテスト用のDBにデータを保存しているため、テストなし
 end

--- a/spec/models/dish_attribute_spec.rb
+++ b/spec/models/dish_attribute_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe DishAttribute, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # すでにテスト用のDBにデータを保存しているため、テストなし
 end

--- a/spec/models/dish_ingredient_spec.rb
+++ b/spec/models/dish_ingredient_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe DishIngredient, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/dish_spec.rb
+++ b/spec/models/dish_spec.rb
@@ -1,5 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Dish, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'varidation' do
+    # 全部ちゃんと入力
+    it 'is valid with all attributes' do
+      dish = create(:dish)
+      expect(dish).to be_valid
+      expect(dish.errors).to be_empty
+    end
+
+    # 味付けがない
+    it 'is invalid without seasoning' do
+      dish_without_seasoning = build(:dish, seasoning_id: '')
+      expect(dish_without_seasoning).to be_invalid
+      expect(dish_without_seasoning.errors.full_messages).to eq ['味付けを入力してください']
+    end
+
+    # 食感がない
+    it 'is invalid without texture' do
+      dish_without_texture = build(:dish, texture_id: '')
+      expect(dish_without_texture).to be_invalid
+      expect(dish_without_texture.errors.full_messages).to eq ['食感を入力してください']
+    end
+
+    # カテゴリーがない
+    it 'is invalid without texture' do
+      dish_without_texture = build(:dish, category_id: '')
+      expect(dish_without_texture).to be_invalid
+      expect(dish_without_texture.errors.full_messages).to eq ['カテゴリーを入力してください']
+    end
+  end
+
+  # こだわりポイントが20文字より多い
+  it 'is invalid with point longer than 20 characters' do
+    dish_with_longer_point = build(:dish, point:'ポイントポイントポイントポイントポイントポイント')
+    expect(dish_with_longer_point).to be_invalid
+    expect(dish_with_longer_point.errors.full_messages).to eq ['こだわりポイントは20文字以内で入力してください']
+  end
+
 end

--- a/spec/models/dishes_ingredient_spec.rb
+++ b/spec/models/dishes_ingredient_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe DishesCookingMethod, type: :model do
+RSpec.describe DishesIngredient, type: :model do
   # 中間テーブルのため、テストなし
 end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -1,5 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Ingredient, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'varidation' do
+    # 食材を3つDBにちゃんと保存できるか確認(dishの関連として生成)
+    it 'is valid with all attributes' do
+      dish = create(:dish, name_1: 'たまご', name_2: 'かつお', name_3: 'たまねぎ')
+      expect(dish).to be_valid
+      expect(dish.errors).to be_empty
+    end
+
+    # 食材なし
+    it 'is invalid without name' do
+      ingredient_without_name = build(:ingredient, name: '')
+      expect(ingredient_without_name).to be_invalid
+      expect(ingredient_without_name.errors.full_messages).to eq ['食材を入力してください','形態素を入力してください']
+    end
+
+    # 食材が15文字以上の場合
+    it 'is invalid name longer than 15 characters' do
+      ingredient = build(:ingredient, name: 'あいうえおかきくけこさしすせそたちつてと')
+      expect(ingredient).to be_invalid
+      expect(ingredient.errors.full_messages).to eq ['食材は15文字以内で入力してください']
+    end
+  end
 end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Like, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # 中間テーブルのため、テストなし
 end

--- a/spec/models/seasoning_spec.rb
+++ b/spec/models/seasoning_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Seasoning, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # 擬似テーブルのため、テストなし
 end

--- a/spec/models/texture_spec.rb
+++ b/spec/models/texture_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Texture, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # 擬似テーブルのため、テストなし
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,8 +2,56 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'varidation' do
+    # 全部ちゃんと入力
     it 'is valid with all attributes' do
-      
+      user = create(:user)
+      expect(user).to be_valid # be_validはテストの対象に対して、'valid?'を呼ぶ
+      expect(user.errors).to be_empty
     end
+
+    # 名前なし
+    it 'is invalid without name' do
+      user_without_name = build(:user, name: '')
+      expect(user_without_name).to be_invalid
+      expect(user_without_name.errors.full_messages).to eq ['ニックネームを入力してください']
+    end
+
+    # 名前が15文字より多い
+    it 'is invalid name longer than 15 characters' do
+      user_with_longer_name = build(:user, name:'あいうえおかきくけこさしすせそたちつてと')
+      expect(user_with_longer_name).to be_invalid
+      expect(user_with_longer_name.errors.full_messages).to eq ['ニックネームは15文字以内で入力してください']
+    end
+
+    # メールアドレスなし
+    it 'is invalid without email' do
+      user_without_email = build(:user, email: '')
+      expect(user_without_email).to be_invalid
+      expect(user_without_email.errors.full_messages).to eq ['メールアドレスを入力してください']
+    end
+
+    # メールアドレスの重複
+    it 'is invalid with same email' do
+      user = create(:user)
+      user_with_same_email = build(:user, email: user.email)
+      user_with_same_email.valid?
+      expect(user_with_same_email).to be_invalid
+      expect(user_with_same_email.errors.full_messages).to eq ['メールアドレスはすでに存在します']
+    end
+    
+    # パスワードなし
+    it 'is invalid without password' do
+      user_without_password = build(:user, password: '')
+      expect(user_without_password).to be_invalid
+      expect(user_without_password.errors.full_messages).to eq ['パスワードは8文字以上で入力してください', 'パスワード確認とパスワードの入力が一致しません']
+    end
+
+    # パスワード確認なし
+    it 'is invalid without password_confirmation' do
+      user_without_password_confirmation = build(:user, password_confirmation: '')
+      expect(user_without_password_confirmation).to be_invalid
+      expect(user_without_password_confirmation.errors.full_messages).to eq ['パスワード確認とパスワードの入力が一致しません', 'パスワード確認を入力してください']
+    end
+
   end
 end


### PR DESCRIPTION
## 概要
issue:#320
- ModelSpecの追加
  - `user_spec.rb`
  - `dish_spec.rb`
  -  `ingredient_spec.rb`
  
- Factoryの修正
  - `dishes.rb`  
    - テストで、`create(:dish ,name_1: 'たまご', name_2: '豚肉')`というように、任意のデータを食材にセットできるようにFactoryを変更した。コードがFat気味なのが気になる...