### PR TITLE
improve:ログインしていないユーザーにはいいねボタンを表示させない

### DIFF
--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -18,11 +18,14 @@
             <p class="card-text ms-3 mb-0"><%= dish.user.name %></p>
           <% end %>
         </div>
-        <%# 自分の料理にはcrudボタン、そうでなければいいねボタン %>
+        <%# 自分の料理にはcrudボタン %>
         <% if current_user&.own?(dish) %>
           <%= render partial: 'dishes/crud_menus', locals: { dish: dish } %>
         <% else %>
-          <%= render partial: 'dishes/likes_button', locals: { dish: dish } %>
+          <%# ログインしていればいいねボタンを表示 %>
+          <% if logged_in? %>
+            <%= render partial: 'dishes/likes_button', locals: { dish: dish } %>
+          <% end %>
         <% end %>
       </div>
       <%# 日付 %>


### PR DESCRIPTION
## 概要
issue:#324
- ログインしていないユーザが「いいね」ボタンを押してしまうと、Hotwireの影響か、ログイン画面にリダイレクトされなかった。そのため、ログインしていないユーザーが「いいね」ボタンを押せないように、非表示にした。