### PR TITLE
add:userのsystemSprcの実装

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,8 @@ group :development, :test do
   # テスト
   gem 'rspec-rails', '~> 6.0.0'
   gem 'factory_bot_rails'
+  gem 'webdrivers'
+  gem 'capybara'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,15 @@ GEM
     bullet (7.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    capybara (3.39.2)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     carrierwave (3.0.2)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -230,6 +239,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
+    matrix (0.4.2)
     meta-tags (2.18.0)
       actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
@@ -378,6 +388,7 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -386,6 +397,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.10.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -437,9 +452,16 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
+    websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     yard (0.9.34)
     zeitwerk (2.6.8)
 
@@ -452,6 +474,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   bullet
+  capybara
   carrierwave (~> 3.0)
   config
   cssbundling-rails
@@ -487,6 +510,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -4,8 +4,9 @@
       <div class="row">
         <div class="col-md-4 mx-auto card-form-content py-5 px-4 my-5 shadow" data-controller='preview'>
           <h3 class="fw-bold text-center mb-5"><%= t('.title') %></h3>
-          <div class=" text-center"><%= image_tag @user.avatar.url, class: 'border border-3 rounded-circle profile-icon shadow', data: { target: 'preview.image' } %></div>
+          <div class=" text-center"><%= image_tag @user.avatar.url, class: 'border border-3 rounded-circle profile-icon shadow mb-4', data: { target: 'preview.image' } %></div>
           <%= form_with model: @user, url: profile_path do |f| %>
+            <%= render partial: 'shared/error_messages', locals: {object: f.object} %>
             <%# アバター %>
             <div class="d-flex align-items-center mt-5">
               <i class="fa-solid fa-image-portrait fa-lg me-3 fa-fw"></i>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,5 +3,4 @@ AIOryouriNaming::Application.config.session_store :redis_store,
                                                   expire_after: 90.minutes,
                                                   key: ENV.fetch('MY_APP_SESSION', nil),
                                                   threadsafe: true,
-                                                  secure: true # 開発環境でもHTTPSを使用しているため、trueとする
-                                                  # 参考(https://github.com/redis-store/redis-rails#session-storage)
+                                                  secure: Rails.env.production? # 開発環境はHTTSだが、テスト環はHTTPSを使用しないため、無効にする

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :user do
     uuid { SecureRandom.uuid }
     sequence(:name, 'user_1') # user_1, user_2, user_3...と作成される
-    sequence(:email) { |n| "user_#{n}@gmail" }
-    password { 'password1234' }
-    password_confirmation { 'password1234' }
+    sequence(:email) { |n| "user_#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
     avatar { nil } # テスト環境でファイルのアップロードをシミュレートする
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -61,4 +61,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+
+  # ログインマクロの読み込み
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+    config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,0 +1,10 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+
+    # Spec実行時、ブラウザが自動で立ち上がり挙動を確認できる
+    # driven_by(:selenium_chrome)
+    
+    # Spec実行時、ブラウザOFF
+    driven_by(:selenium_chrome_headless)
+  end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login(user)
+    visit login_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+    click_on 'ログイン'
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  let(:user) { create(:user) } # ログインするために事前にuserを作成しておく
+
+  describe 'ログイン前' do
+    describe 'ユーザーの新規登録' do
+      context 'フォームの入力値が正常' do
+        it 'ユーザーの新規登録が成功する' do
+          visit sign_up_path
+          fill_in 'user[name]', with: 'AIロボくん'
+          fill_in 'user[email]', with: 'email@example.com'
+          fill_in 'user[password]', with: 'password'
+          fill_in 'user[password_confirmation]', with: 'password'
+          click_button '登録'
+          expect(page).to have_content('料理情報を入力しよう')
+          expect(current_path).to eq root_path
+        end
+      end
+
+      context 'ニックネームが未入力' do
+        it 'ユーザーの新規登録が失敗する' do
+          visit sign_up_path
+          fill_in 'user[name]', with: ''
+          fill_in 'user[email]', with: 'email@example.com'
+          fill_in 'user[password]', with: 'password'
+          fill_in 'user[password_confirmation]', with: 'password'
+          click_button '登録'
+          expect(page).to have_content('ニックネームを入力してください')
+          expect(current_path).to eq sign_up_path
+        end
+      end
+
+      context 'ニックネームが15文字より多い' do
+        it 'ユーザーの新規登録が失敗する' do
+          visit sign_up_path
+          fill_in 'user[name]', with: 'AIロボくんAIロボくんAIロボくんAIロボくんAIロボくん'
+          fill_in 'user[email]', with: 'email@example.com'
+          fill_in 'user[password]', with: 'password'
+          fill_in 'user[password_confirmation]', with: 'password'
+          click_button '登録'
+          expect(page).to have_content('ニックネームは15文字以内で入力してください')
+          expect(current_path).to eq sign_up_path
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'ユーザーの新規登録が失敗する' do
+          visit sign_up_path
+          fill_in 'user[name]', with: 'AIロボくん'
+          fill_in 'user[email]', with: ''
+          fill_in 'user[password]', with: 'password'
+          fill_in 'user[password_confirmation]', with: 'password'
+          click_button '登録'
+          expect(page).to have_content('メールアドレスを入力してください')
+          expect(current_path).to eq sign_up_path
+        end
+      end
+
+      context '登録済みのメールアドレスと使用' do
+        it 'ユーザーの新規登録が失敗する' do
+          existed_user = create(:user)
+          visit sign_up_path
+          fill_in 'user[name]', with: 'AIロボくん'
+          fill_in 'user[email]', with: existed_user.email
+          fill_in 'user[password]', with: 'password'
+          fill_in 'user[password_confirmation]', with: 'password'
+          click_button '登録'
+          expect(page).to have_content('メールアドレスはすでに存在します')
+          expect(current_path).to eq sign_up_path
+        end
+      end
+    end
+  end
+
+  describe 'ログイン後' do
+    before do
+      login(user)
+      expect(page).to have_content('料理情報を入力しよう') # Topページに遷移したことを確認してから、編集ページに遷移(こうしないと、処理が早すぎてログインが完了する前に編集ページに遷移しようとしてしまう)
+      visit edit_profile_path
+    end
+    describe 'プロフィール編集' do
+      context 'フォームの入力が正常' do
+        it 'プロフィールの編集が成功する' do
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
+          fill_in 'user[name]', with: 'updateロボくん'
+          fill_in 'user[email]', with: 'update@example.com'
+          click_on '更新'
+          expect(find_field('user[name]').value).to eq 'updateロボくん' # フォームに値が入っているかチェック
+          expect(find_field('user[email]').value).to eq 'update@example.com'
+          expect(current_path).to eq edit_profile_path
+        end
+      end
+
+      context 'ニックネームが未入力' do
+        it 'プロフィールの編集が成功する' do
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
+          fill_in 'user[name]', with: ''
+          fill_in 'user[email]', with: 'update@example.com'
+          click_on '更新'
+          expect(page).to have_content('ニックネームを入力してください')
+        end
+      end
+
+      context 'ニックネームが15文字より多い' do
+        it 'プロフィールの編集が失敗する' do
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
+          fill_in 'user[name]', with: 'AIロボくんAIロボくんAIロボくんAIロボくんAIロボくん'
+          fill_in 'user[email]', with: 'update@example.com'
+          click_button '更新'
+          expect(page).to have_content('ニックネームは15文字以内で入力してください')
+        end
+      end
+
+      context 'メールアドレスが未入力' do
+        it 'プロフィールの編集が失敗する' do
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
+          fill_in 'user[name]', with: 'updateロボくん'
+          fill_in 'user[email]', with: ''
+          click_on '更新'
+          expect(page).to have_content('メールアドレスを入力してください')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
issue:#337
- userの新規登録、プロフィール編集に係るsystemSpecの実装を行なった。
- `gem 'capybara', 'webdrivers'`のインストールを行なった。
- テスト中のlogin処理をmoduleとして切り出し、LoginMacrosを設けた。