### PR TITLE
add:generate_formのリファクタリング、料理名生成失敗時のエラーメッセージの表示

### DIFF
--- a/app/forms/generate_form.rb
+++ b/app/forms/generate_form.rb
@@ -1,7 +1,7 @@
 class GenerateForm
   require 'tiny_segmenter' # 形態素解析
   require 'nkf' # カタカナをひらがなに変換
-  include ActiveModel::Model
+  include ActiveModel::Model # form_withやerrorsを使えるようになったり、バリデーションの設定ができる
   include ActiveModel::Attributes
   extend CarrierWave::Mount
 
@@ -20,54 +20,101 @@ class GenerateForm
   validates :name_1, length: { maximum: 15 }
   validates :name_2, length: { maximum: 15 }
   validates :name_3, length: { maximum: 15 }
-  validates :cooking_methods, presence: true
-  validates :seasoning_id, presence: true
-  validates :texture_id, presence: true
-  validates :category_id, presence: true
-  validates :point, length: { maximum: 20 }
+
+  # カスタムバリデーション
+  validate :check_ingredient_presence
+  validate :check_cooking_method_presence
+
+  # 以下は各モデルのバリデーションで処理する
+  # validates :cooking_methods, presence: true
+  # validates :seasoning_id, presence: true
+  # validates :texture_id, presence: true
+  # validates :category_id, presence: true
+  # validates :point, length: { maximum: 20 }
 
   def save_dish(current_user, ip_address)
-    # 料理名生成時にログインしていなければ、ゲストユーザー設定をする
-    # user.rbでcurrent_userを使用できるよう、引数を渡す
-    user = User.setup_guest_if_not_logedin(current_user)
 
-    begin
-      # 一つでも失敗したら保存しない
-      ActiveRecord::Base.transaction do
-        @dish = user.dishes.new(dish_params)
-        # 食材
-        names = [name_1, name_2, name_3].select(&:present?) # フォームに入力されていない時、空白が送られるため空白を削除
-        names.each do |name|
-          ingredient = Ingredient.find_by(name:)
-          unless ingredient # DBに保存されている食材でない場合、形態素解析をし、createする
-            morphemes = morphological_analysis(name)
-            ingredient = Ingredient.create(name:, morphemes:)
+    # 一つでも失敗したら保存しない
+    ActiveRecord::Base.transaction do
+      
+      # 料理名生成時にログインしていなければ、ゲストユーザー設定をする
+      # user.rbでcurrent_userを使用できるよう、引数を渡す
+      user = User.setup_guest_if_not_logedin(current_user)
+      # userに紐づけた@dishを作成
+      @dish = user.dishes.new(dish_params)
+      # 食材を@dishに関連付ける
+      associate_ingredients_to_dish
+      # 調理法を@dishに関連づける
+      associate_cooking_methods_to_dish
+
+      # formObject(@generate_dish)と@dishにバリデーションを実行(valid?は、失敗したら@generate_formにエラーオブジェクトが追加される)
+      if valid? && @dish.valid?
+        # バリデーションが通ったらmodalを表示させる
+        show_loading_modal(ip_address)
+      else
+        # valid?がfalseの場合、@dish.valid?が検証されないため、@dish.valid?をここで実行
+        unless @dish.valid?
+          # @dishのエラーメッセージを@generate_fromに追加してあげる(form_withで@generate_formを使用しているため)
+          @dish.errors.full_messages.each do |error_message|
+            errors.add(:base, error_message) # errorsは、self.errorsのこと
           end
-          @dish.ingredients << ingredient
         end
-        # 調理法
-        cooking_methods.each do |cooking_method|
-          @dish.cooking_methods << CookingMethod.find_by(name: cooking_method)
-        end
-        if @dish.valid? # バリデーションが通ったらすぐmodalを表示させる
-          ActionCable.server.broadcast( # modal表示するためのメッセージをコンシューマーに送信
-            "loading_channel_#{ip_address}", { event: 'showLoadingModal' }
-          )
-        end
-        @dish.save! # 保存できない場合は、例外を発生させて全ての処理をロールバックさせる(例外を発生させないと、処理がロールバックされず、DBに保存されてしまう)
+        # バリデーションに通らなかったら例外を発生させて、トランザクションを全てrollbackさせる
+        raise ActiveRecord::Rollback
       end
-    # 例外が発生しても、createメソッドに戻れるようrescueする
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::NotNullViolation # NotNull~は食材が全部空のとき出るエラー
-      return @dish # 例外が発生した場合、@dishは不完全なものであるため、createメソッドのelse句が走る(例外が発生しなかった場合は、trueが返る)
+      # バリデーションが全て通ったら、保存処理をする
+      @dish.save
     end
-    @dish # 例外が発生しなかった場合、rescue節内の@dishにはtrueが代入されてしまうため、返り値を設定
+    # @dishを返す
+    @dish
   end
 
   private
 
   def dish_params
-    { seasoning_id:, texture_id:, category_id:,
-      point:, dish_image:, dish_image_cache: }
+    { seasoning_id: seasoning_id, texture_id: texture_id, category_id: category_id,
+      point: point, dish_image: dish_image, dish_image_cache: dish_image_cache}
+  end
+
+  # 食材が最低一つは入力されているか確認
+  def check_ingredient_presence
+    unless [name_1, name_2, name_3].any?(&:present?)
+      errors.add(:base, '食材は一つ以上入力してください')
+    end
+  end
+
+  # 調理法が最低一つは入力されているか確認
+  def check_cooking_method_presence
+    unless cooking_methods.any?(&:present?)
+      errors.add(:base, '調理法は一つ以上選択してください')
+    end
+  end
+
+  # 食材を@dishに関連づける
+  def associate_ingredients_to_dish
+    names = [name_1, name_2, name_3].select(&:present?) # フォームに入力されていない時、空白が送られるため空白を削除
+    names.each do |name|
+      ingredient = Ingredient.find_by(name: name)
+      unless ingredient # DBに保存されていない食材のみ形態素解析をし、createする
+        morphemes = morphological_analysis(name)
+        ingredient = Ingredient.create(name: name, morphemes: morphemes)
+      end
+      @dish.ingredients << ingredient
+    end
+  end
+
+  # 調理法を@dishに関連づける
+  def associate_cooking_methods_to_dish
+    cooking_methods.each do |cooking_method|
+      @dish.cooking_methods << CookingMethod.find_by(name: cooking_method)
+    end
+  end
+
+  # 考え中ですモーダルを表示
+  def show_loading_modal(ip_address)
+    ActionCable.server.broadcast( # modal表示するためのメッセージをコンシューマーに送信
+      "loading_channel_#{ip_address}", { event: 'showLoadingModal' }
+    )
   end
 
   # 形態素解析(カンマ区切りの文字列にしてmorphemesカラムに格納)

--- a/app/views/dishes/new.html.erb
+++ b/app/views/dishes/new.html.erb
@@ -37,6 +37,7 @@
 <div class="main-content">
 <h5 class="main-content-title fw-bold text-center pt-5 pb-4">▼ 料理情報を入力しよう ▼</h5>
   <%= form_with model: @generate_form, url: dishes_path do |f| %>
+    <%= render partial: 'shared/error_messages', locals: { object: f.object } %>
     <%# 食材 %>
     <div class="ingredient">
       <div class="container">

--- a/config/locales/activemodel/ja.yml
+++ b/config/locales/activemodel/ja.yml
@@ -4,5 +4,8 @@ ja:
       generate_form:
     attributes:
       generate_form:
+        name_1: '食材'
+        name_2: '食材'
+        name_3: '食材'
         point: 'こだわりポイント'
         dish_image: '料理写真'

--- a/spec/system/dishes_spec.rb
+++ b/spec/system/dishes_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Dishes", type: :system do
       end
 
       context 'こだわりポイントが20文字より多い' do
-        fit '料理名の生成が失敗する' do
+        it '料理名の生成が失敗する' do
           fill_in 'generate_form[name_1]', with: 'にんじん'
           fill_in 'generate_form[name_2]', with: 'だいこん'
           fill_in 'generate_form[name_3]', with: '豚肉'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Users', type: :system do
     describe 'プロフィール編集' do
       context 'フォームの入力が正常' do
         it 'プロフィールの編集が成功する' do
-          attach_file('user[avatar]', Rails.root.join('spec/factories/test.png').to_s)
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
           fill_in 'user[name]', with: 'updateロボくん'
           fill_in 'user[email]', with: 'update@example.com'
           click_on '更新'
@@ -94,7 +94,7 @@ RSpec.describe 'Users', type: :system do
 
       context 'ニックネームが未入力' do
         it 'プロフィールの編集が成功する' do
-          attach_file('user[avatar]', Rails.root.join('spec/factories/test.png').to_s)
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
           fill_in 'user[name]', with: ''
           fill_in 'user[email]', with: 'update@example.com'
           click_on '更新'
@@ -104,7 +104,7 @@ RSpec.describe 'Users', type: :system do
 
       context 'ニックネームが15文字より多い' do
         it 'プロフィールの編集が失敗する' do
-          attach_file('user[avatar]', Rails.root.join('spec/factories/test.png').to_s)
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
           fill_in 'user[name]', with: 'AIロボくんAIロボくんAIロボくんAIロボくんAIロボくん'
           fill_in 'user[email]', with: 'update@example.com'
           click_button '更新'
@@ -114,7 +114,7 @@ RSpec.describe 'Users', type: :system do
 
       context 'メールアドレスが未入力' do
         it 'プロフィールの編集が失敗する' do
-          attach_file('user[avatar]', Rails.root.join('spec/factories/test.png').to_s)
+          attach_file('user[avatar]', "#{Rails.root}/spec/factories/test.png")
           fill_in 'user[name]', with: 'updateロボくん'
           fill_in 'user[email]', with: ''
           click_on '更新'


### PR DESCRIPTION
## 概要
issue:#344
- `generate_form`のリファクタリングを行なった。

-  また、料理名生成フォームに正常に値が入力・選択されていない時に、エラーメッセージが表示されるよう、修正した。
   - formObject内で定義したバリデーションは、`valid?`で`@generate_form`に対して実行される
   - 各モデル(`dish(pointについて), seasoning, texture, category`)に定義したバリデーションは、`@dish.valid?`で`@dish`に対して実行される
     - ※`@dish = user.dishes.new(dish_params)`で@dishに関連づけられている