### PR TITLE
add:料理カードの写真をMiniMagickでリサイズするよう設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,9 @@ gem 'kaminari'
 # 画像アップロード
 gem 'carrierwave', '~> 3.0'
 
+# 画像編集
+gem "mini_magick"
+
 # AWS接続用
 gem 'fog-aws'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -489,6 +489,7 @@ DEPENDENCIES
   kaminari
   letter_opener_web (~> 2.0)
   meta-tags
+  mini_magick
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)

--- a/app/uploaders/dish_image_uploader.rb
+++ b/app/uploaders/dish_image_uploader.rb
@@ -1,4 +1,11 @@
 class DishImageUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+  
+  version :dish_card do
+    process process resize_to_fill: [320, 240, gravity='Center']
+  end
+
+
   # storage :file
   storage :fog
 

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -1,7 +1,7 @@
 <div class="col-xl-4 col-md-6 mt-5">
   <div class="card dish-card">
     <div class="card-img-block">
-      <%= image_tag dish.dish_image_url, class:'card-img-top' %>
+      <%= image_tag dish.dish_image_url(:dish_card), class:'card-img-top' %>
     </div>
     <div class="card-body pt-0">
       <%# 自分の料理一覧ページにいる且つ「公開中」なら、「公開中」マークつける %>
@@ -14,7 +14,7 @@
       <div class="d-flex align-items-center mt-3">
         <div class="flex-grow-1 d-flex align-items-center">
           <%= link_to user_path(dish.user.uuid), class:'d-flex align-items-center card-link ' do %>
-            <%= image_tag dish.user.avatar.url , class: 'rounded-circle border border-3 card-avatar' %>
+            <%= image_tag dish.user.avatar.url, class: 'rounded-circle border border-3 card-avatar' %>
             <p class="card-text ms-3 mb-0"><%= dish.user.name %></p>
           <% end %>
         </div>


### PR DESCRIPTION
## 概要
issue:#355
- `gem mini_magick`を導入し、料理掲示板のサムネイル画像を320x240にリサイズするよう設定した。