### PR TITLE
add:gem'deepl-rb'の導入と、調理法・味付け・食感・カテゴリーに英訳データを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ gem 'redis-actionpack'
 # 形態素解析
 gem 'tiny_segmenter'
 
+# 翻訳
+gem 'deepl-rb', require: 'deepl'
+
 # 利用規約・プライバシーポリシーに使用
 gem 'high_voltage', '~> 3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       reline (>= 0.3.1)
     debug_inspector (1.1.0)
     deep_merge (1.2.2)
+    deepl-rb (2.5.3)
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -479,6 +480,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  deepl-rb
   dotenv-rails
   enum_help
   factory_bot_rails

--- a/app/models/cooking_method.rb
+++ b/app/models/cooking_method.rb
@@ -3,4 +3,5 @@ class CookingMethod < ApplicationRecord
   has_many :dishes, through: :dishes_cookind_methods
 
   validates :name, presence: true, uniqueness: true
+  validates :name_en, uniqueness: true
 end

--- a/db/migrate/20231003145605_add_column_to_dish_attributes.rb
+++ b/db/migrate/20231003145605_add_column_to_dish_attributes.rb
@@ -1,0 +1,5 @@
+class AddColumnToDishAttributes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dish_attributes, :name_en, :string
+  end
+end

--- a/db/migrate/20231004004206_add_column_to_cooking_methods.rb
+++ b/db/migrate/20231004004206_add_column_to_cooking_methods.rb
@@ -1,0 +1,6 @@
+class AddColumnToCookingMethods < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cooking_methods, :name_en, :string
+    add_index :cooking_methods, :name_en, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_043326) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_04_004206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_043326) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name_en"
     t.index ["name"], name: "index_cooking_methods_on_name", unique: true
+    t.index ["name_en"], name: "index_cooking_methods_on_name_en", unique: true
   end
 
   create_table "dish_attributes", force: :cascade do |t|
@@ -35,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_043326) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name_en"
   end
 
   create_table "dishes", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,15 @@
-# 10.times do |n|
-#   User.create!(
-#     name: "テストユーザー#{n + 1}",
-#     email: "test#{n + 1}@test"
-#   )
-# end
-
 # 調理法
 cooking_methods = %w[炒める 煮る 煮込む 炒め煮 揚げる 蒸す 蒸し焼き 焼く 和える グリル ロースト マリネ]
-
 cooking_methods.each do |cooking_method|
   CookingMethod.find_or_create_by(name: cooking_method)
+end
+
+# 調理法(英訳)
+cooking_methods_en = %w[stir-fry simmer stew braise deep-fry steam steam&fry fry dress grill roast marinade]
+cooking_methods_en.each_with_index do |cooking_method_en, i|
+  cooking_method_first_id = CookingMethod.first.id
+  cooking_method = CookingMethod.find(cooking_method_first_id + i)
+  CookingMethod.update(name_en: cooking_method_en)
 end
 
 # 味付け
@@ -18,14 +18,38 @@ seasonings.each do |seasoning|
   Seasoning.find_or_create_by(name: seasoning)
 end
 
+# 味付け(英訳)
+seasonings_en = %w[light greasy sweet&spicy sour chili stock garlic spicy butter]
+seasonings_en.each_with_index do |seasoning_en, i|
+  seasoning_first_id = Seasoning.first.id
+  seasoning = Seasoning.find(seasoning_first_id + i)
+  seasoning.update(name_en: seasoning_en)
+end
+
 # 食感
 textures = %w[ジューシー ごろごろ ホロホロ やわらか とろっと もちもち ぷりぷり なめらか ねばねば サクサク シャキシャキ クリーミー]
 textures.each do |texture|
   Texture.find_or_create_by(name: texture)
 end
 
+# 食感(英訳)
+textures_en = %w[juicy substantial crumbly soft chewy plump smooth sticky crispy crisp creamy]
+textures_en.each_with_index do |textures_en, i|
+  texture_first_id = Texture.first.id
+  texture = Texture.find(texture_first_id + i)
+  texture.update(name_en: textures_en)
+end
+
 # カテゴリー
 categories = %w[和風 中華 洋風 韓国 フレンチ イタリアン エスニック インド 自己流]
 categories.each do |category|
   Category.find_or_create_by(name: category)
+end
+
+# カテゴリー(英訳)
+categories_en = %w[Japanese Chinese Western Korean French Italian Ethnic Indian Self-styled]
+categories_en.each_with_index do |categories_en, i|
+  category_first_id = Category.first.id
+  category = Category.find(category_first_id + i)
+  category.update(name_en: categories_en)
 end


### PR DESCRIPTION
## 概要
issue:#357
- stability AI APIに投げるプロンプトは英語のため、食材・こだわりポイントを英訳できるようDeepL APIをRubyから操作できるdeepl-rbを導入した。
- また調理法・味付け・食感・カテゴリーは規定値のため、それぞれのテーブルにname_enカラムを追加し、英訳データを格納した。