### PR TITLE
fix:seedファイルの食感(英訳)データが、11種類になっており、1種類少なかったため追加した

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,7 +33,7 @@ textures.each do |texture|
 end
 
 # 食感(英訳)
-textures_en = %w[juicy substantial crumbly soft chewy plump smooth sticky crispy crisp creamy]
+textures_en = %w[juicy substantial crumbly soft thick&smooth chewy plump smooth sticky crispy crisp creamy]
 textures_en.each_with_index do |textures_en, i|
   texture_first_id = Texture.first.id
   texture = Texture.find(texture_first_id + i)


### PR DESCRIPTION
## 概要
issue:#357
- seedファイルに誤りがあった。食感の英訳データが11種類しか用意しておらず、1種類足りなかったため追加した。