### PR TITLE
fix:ライブラリ名を正しく修正した

### DIFF
--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -2,7 +2,7 @@ class Dish < ApplicationRecord
   require 'openai'
   require 'dotenv'
   Dotenv.load
-  require 'Faraday'
+  require 'faraday'
   require 'json'
   require 'base64'
 


### PR DESCRIPTION
## 概要
issue:#360
- `dish.rb`で、`require 'Faraday'`としていたため、`require 'faraday'`と修正した。