### PR TITLE
add:料理情報から料理写真を生成できるように修正

### DIFF
--- a/app/models/dish.rb
+++ b/app/models/dish.rb
@@ -1,11 +1,5 @@
 class Dish < ApplicationRecord
-  require 'openai'
-  require 'dotenv'
-  Dotenv.load
-  require 'faraday'
-  require 'json'
-  require 'base64'
-
+  
   before_create -> { self.uuid = SecureRandom.uuid }
   # レコード新規作成時のみ、generateメソッドを実行する
   after_commit :generate_dish_name, on: :create
@@ -72,6 +66,9 @@ class Dish < ApplicationRecord
       headers: {'Authorization' => ENV['STABILITY_API_KEY'],
                 'Content-Type' => 'application/json'}
     )
+
+    ingredients_en = DeepL.translate "#{ingredients.pluck(:name).join(',')}", 'JA', 'EN'
+    point_en = DeepL.translate "#{point}", 'JA', 'EN'
     
     body = {
       cfg_scale: 7,
@@ -81,7 +78,7 @@ class Dish < ApplicationRecord
       steps: 30,
       text_prompts: [
       {
-      text: "Stir-fried poke and eggplant, sweet&spicy, greasy, high detail, food photography , Bokeh effect, on a plate",
+      text: "#{ingredients_en}, #{cooking_methods.pluck(:name_en).join(',')}, #{seasoning.name_en}, #{texture.name_en}, #{category.name_en}, #{point_en}, high detail, food photography , Bokeh effect, on a plate",
       weight: 1
       }
       ]

--- a/config/initializers/deepl.rb
+++ b/config/initializers/deepl.rb
@@ -1,0 +1,8 @@
+require 'deepl'
+require 'dotenv'
+Dotenv.load
+
+DeepL.configure do |config|
+  config.auth_key = ENV['DEEPL_AUTH_KEY']
+  config.host = 'https://api-free.deepl.com'
+end

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,1 @@
+require 'faraday'

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,0 +1,1 @@
+require 'openai'


### PR DESCRIPTION
## 概要
issue:#363
- フォームから入力された情報を、StabilityAI APIに送信して、料理写真を生成できるように修正。
- 食材・こだわりポイントについては、DeepLAPIで英語に翻訳してから、APIに投げている。他の項目については、あらかじめname_enカラムに英訳データがあるので、それをAPIに投げている。