### PR TITLE
improve:StabilityAI APIを0.8verに戻した

### DIFF
--- a/app/clients/stability_client.rb
+++ b/app/clients/stability_client.rb
@@ -11,8 +11,8 @@ class StabilityClient
   def post_to_stability_api(ingredients_en, cooking_methods, seasoning, texture, category, point_en)
     body = {
       cfg_scale: 7,
-      height: 1024,
-      width: 1024,
+      height: 512,
+      width: 512,
       samples: 1,
       steps: 30,
       text_prompts: [


### PR DESCRIPTION
## 概要
issue:#372
- 最新モデルだと画像生成に時間がかかりすぎて処理が重くなるため、0.8verモデルに戻した。