### PR TITLE
improve:料理生成結果画面・料理詳細画面を含めた、すべてのページの料理画像を320x240に変更する

### DIFF
--- a/app/assets/stylesheets/custom/style.scss
+++ b/app/assets/stylesheets/custom/style.scss
@@ -296,8 +296,8 @@
   &-dish-image img {
     border-radius:5px;
     box-shadow:0 0 10px rgba(0,0,0,0.63);
-    width: 320px;
-    height: 100%;
+    // width: 320px;
+    // height: 100%;
     object-fit: cover;
   }
 
@@ -591,4 +591,13 @@
 // 利用規約・プライバシーポリシーの背景
 .privacy-and-terms-of-use {
   background-color: $very-light-yellow;
+}
+
+// プレビュー
+.preview-dish-image img {
+  border-radius:5px;
+  box-shadow:0 0 10px rgba(0,0,0,0.63);
+  width: 320px;
+  height: 100%;
+  object-fit: cover;
 }

--- a/app/clients/stability_client.rb
+++ b/app/clients/stability_client.rb
@@ -3,8 +3,8 @@ class StabilityClient
     @conn = Faraday.new(
       url: ENV.fetch('STABILITY_URL', nil),
       headers: { 'Authorization' => ENV.fetch('STABILITY_API_KEY', nil),
-                 'Content-Type' => 'application/json',
-                 'Accept' => 'application/json' }
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json' }
     )
   end
 

--- a/app/views/dishes/_dish.html.erb
+++ b/app/views/dishes/_dish.html.erb
@@ -1,7 +1,7 @@
 <div class="col-xl-4 col-md-6 mt-5">
   <div class="card dish-card">
     <div class="card-img-block">
-      <%= image_tag dish.dish_image_url(:dish_card), class:'card-img-top' %>
+      <%= image_tag dish.dish_image.url(:dish_card), class:'card-img-top' %>
     </div>
     <div class="card-body pt-0">
       <%# 自分の料理一覧ページにいる且つ「公開中」なら、「公開中」マークつける %>

--- a/app/views/dishes/_result.html.erb
+++ b/app/views/dishes/_result.html.erb
@@ -17,7 +17,7 @@
     <div class="row">
       <div class="col-md-6 mx-auto">
         <h3 class="text-center my-4 result-dish-name py-5 px-3 fw-bold highlight"><%= dish.dish_name %></h3>
-        <div class="text-center my-5 result-dish-image"><%= image_tag dish.dish_image_url %></div>
+        <div class="text-center my-5 result-dish-image"><%= image_tag dish.dish_image.url(:dish_card) %></div>
       </div>
     </div>
   </div>

--- a/app/views/dishes/_similar_dish_modal.html.erb
+++ b/app/views/dishes/_similar_dish_modal.html.erb
@@ -2,7 +2,7 @@
 <div class="similar-dish-modal hidden" data-similar-dish-target='modal'>
   <div class="card similar-dish-card">
     <div class="similar-dish-card-img-block">
-      <%= image_tag similar_dish.dish_image_url, class:'card-img-top' %>
+      <%= image_tag similar_dish.dish_image.url(:dish_card), class:'card-img-top' %>
     </div>
     <div class="card-body pt-0">
       <%# 料理名 %>

--- a/app/views/dishes/edit.html.erb
+++ b/app/views/dishes/edit.html.erb
@@ -15,7 +15,7 @@
         <%= f.label :dish_image, class: 'form-label' %>
         <%= f.file_field :dish_image, class: 'form-control', accept: 'image/*' %>
         <%= f.hidden_field :dish_image_cache %>
-        <div class="result-dish-image my-4"><%= image_tag @dish.dish_image.url, id: 'preview' %></div>
+        <div class="result-dish-image my-4"><%= image_tag @dish.dish_image.url(:dish_card), data: { target: 'preview.image' } %></div>
       </div>
     </div>
     <div class="text-center mx-auto"">

--- a/app/views/dishes/new.html.erb
+++ b/app/views/dishes/new.html.erb
@@ -41,7 +41,7 @@
       <div class="col-md-4 mx-auto">
         <div class="card new-arrival-dish-card">
           <div class="new-arrival-dish-card-img-block">
-            <%= image_tag @new_arrival.dish_image_url(:dish_card), class:'card-img-top' %>
+            <%= image_tag @new_arrival.dish_image.url(:dish_card), class:'card-img-top' %>
           </div>
           <div class="card-body pt-0">
             <%= render partial: 'dishes/new_arrival' %>
@@ -143,7 +143,7 @@
           <%= f.file_field :dish_image, class: 'form-control mt-2', accept: 'image/*', data: { action: 'change->preview#previewImage'} %> <%# previewコントローラーのpreviewImageメソッドを呼び出し%>
           <%= f.hidden_field :dish_image_cache %>
           <%# previewコントローラーでimageをtargetとして設定%>
-            <div class="result-dish-image mt-4 mb-2" ><%= image_tag @dish.dish_image.url, data: { target: 'preview.image' } %></div>
+            <div class="preview-dish-image mt-4 mb-2" ><%= image_tag @dish.dish_image.url(:dish_card), data: { target: 'preview.image' } %></div>
           <div class="form-text mt-3">※写真をアップロードしなかった場合、<b><u>自動で料理写真が生成</u></b>されます。</div>
         </div>
       </div>

--- a/app/views/dishes/show.html.erb
+++ b/app/views/dishes/show.html.erb
@@ -2,7 +2,7 @@
 <div class="board-background">
   <div class="card-form-bg-none px-3">
     <h3 class="fw-bold text-center pt-5 dish-title"><%= @dish.dish_name %></h3>
-    <div class="text-center mt-5 my-4 result-dish-image "><%= image_tag @dish.dish_image_url %></div>
+    <div class="text-center mt-5 my-4 result-dish-image "><%= image_tag @dish.dish_image.url(:dish_card) %></div>
     <div class="container">
       <div class="row">
         <div class="col-md-6 mx-auto card-form-content py-4 px-4 mt-4 mb-5 shadow">


### PR DESCRIPTION
## 概要
issue:#375
- 料理生成結果画面と料理詳細画面に料理画像が表示されないのは、画像サイズが大きく読み込み処理に不可がかかっている可能性があるため、全ての料理画像をmini_magickで明示的に320x240にサイズに変更をしてみる