### PR TITLE
fix:本番環境で、管理者ログイン画面が表示されない問題を修正

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -3,6 +3,8 @@ module Admin
     # 管理者用controllerの共通の処理はここに書く
     before_action :check_admin
 
+    private
+
     # ログインしていなければ、ログイン画面に飛ばす
     def not_authenticated
       redirect_to admin_login_path, warning: t('defaults.message.require_login')

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,5 +1,5 @@
 module Admin
-  class DashboardsController < ApplicationController
+  class DashboardsController < Admin::BaseController
     def index; end
   end
 end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class UserSessionsController < Admin::BaseController
     skip_before_action :require_login, only: %i[new create]
+    skip_before_action :check_admin, only: %i[new create]
 
     def new; end
 


### PR DESCRIPTION
## 概要
issue:#394
- ログイン画面遷移時点では、current_userはnilであるため、check_adminによってエラーが発生していた。そこで。`user_sessions_controller`に`skip_before_action`を追加した。
- また`base_controller`が`Admin::BaseController`を継承するよう修正した。