### PR TITLE
fix:ゲストユーザーの作成はdish.saveより前に行うよう修正した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
 
   def self.setup_guest_if_not_logedin(current_user)
     if current_user.nil?
-      User.new(
+      User.create(
         name: ENV.fetch('USER_NAME', nil),
         email: "#{SecureRandom.alphanumeric(10)}@email.com",
         password: 'password',


### PR DESCRIPTION
## 概要
issue:#396
- ゲストユーザはdishに関連づけて、dish.saveによってDBに情報を保存していたが、dish.saveを行う前にあらかじめ作成するようにした。